### PR TITLE
Add session-management feature (WIP, do not merge yet)

### DIFF
--- a/board/mysessions.cgi
+++ b/board/mysessions.cgi
@@ -1,0 +1,49 @@
+#!/usr/bin/perl -w
+use strict;
+use lib '../lib';
+use Bawi::Auth;
+use Bawi::Board;
+use Bawi::Board::UI;
+use HTML::ParseBrowser;
+use GeoIP2::WebService::Client;
+
+my $ui = new Bawi::Board::UI;
+my $auth = new Bawi::Auth(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
+my $DBH = $ui->dbh;
+unless ($auth->auth) {
+    print $auth->login_page($ui->cgiurl);
+    exit (1);
+}
+
+################################################################################
+## main
+################################################################################
+my ($uid, $id, $name, $session_key);
+if ($auth->auth) {
+    ($uid, $id, $name, $session_key) = ($auth->uid, $auth->id, $auth->name, $auth->session_key);
+} else {
+    ($uid, $id, $name, $session_key) = (0, 'guest', 'guest', '');
+}
+
+# SECURITY: hardcoded GeoIP2 credentials removed (were exposed in a public push; rotate the key and load from config before enabling this feature).
+my $geoip_account_id  = '';   # TODO: load from conf/*.conf
+my $geoip_license_key = '';   # TODO: load from conf/*.conf
+my $client = GeoIP2::WebService::Client->new(account_id=>$geoip_account_id, license_key=>$geoip_license_key);
+my $insights = $client->insights(ip => $ENV{'REMOTE_ADDR'});
+my $ip = $insights->city()->name().", ".$insights->country()->name();
+$ui->init(-template=>'mysessions.tmpl');
+my $t = $ui->template;
+$t->param(HTMLTitle=>"나의 접속 기기 보기 ".$name."(".$id.")");
+$t->param(name=>$name);
+$t->param(id=>$id);
+$t->param(url=>"mysessions");
+$t->param(ua=>$ip);
+my $sql = qq(SELECT session_key, uid, id, name, created, ip_address, user_agent FROM bw_xauth_session WHERE uid=?);
+my $rv = $DBH->selectall_hashref($sql, "uid", undef, $uid);
+my @rv = map { $rv->{$_} } sort {$b <=> $a} keys %$rv;
+$t->param(sessions=>\@rv);
+
+# navigation
+print $ui->output;
+
+1;

--- a/board/remove_session.cgi
+++ b/board/remove_session.cgi
@@ -1,0 +1,106 @@
+#!/usr/bin/perl -w
+use strict;
+use lib '../lib';
+use CGI;
+
+use Bawi::Auth;
+use Bawi::Board::Config;
+use Bawi::Board::UI;
+use Bawi::DBI;
+use overload;
+
+my $q = new CGI;
+my $cfg = new Bawi::Board::Config;
+my $auth = new Bawi::Auth(-cfg => $cfg);
+
+my ($session_key) =
+    map { $q->param($_) || undef } qw( session_key );
+
+
+sub objectToString {
+    my $obj    = shift; # object to convert to string
+    my $indent = shift; # indentation level. Defaults to 0.
+
+    $indent = 0 unless( defined( $indent ));
+    return 'undef' unless( defined( $obj ));
+
+    my $ret = '';
+
+    my $strval = overload::StrVal( $obj );
+
+    my ($realpack, $realtype, $id) = ($strval =~ /^(?:(.*)\=)?([^=]*)\(([^\(]*)\)$/);
+    $realpack = '' unless( $realpack );
+    $realtype = '' unless( $realtype );
+    $id = '' unless( $id );
+
+    if( $realpack eq "Math::BigInt" ) {
+        $ret .= ref( $obj ) . " { ";
+        $ret .= $obj->bstr;
+        $ret .= " }";
+    } elsif( $realtype eq "ARRAY" ) {
+        $ret .= ref( $obj ) . " {\n";
+        # check whether this is a pseudo-hash
+        if( @{$obj} && overload::StrVal( @{$obj}[0] ) =~ m!^pseudohash=! ) {
+            my $pseudo = @{$obj}[0];
+            foreach my $k ( keys %{$pseudo} ) {
+                $ret .= indent( $indent+1 );
+                $ret .= sprintf( "%-32s => %s\n", $k, objectToString( @{$obj}[ $pseudo->{$k} ], $indent+1 ));
+            }
+        } else {
+            foreach my $o ( @{$obj} ) {
+                $ret .= indent( $indent+1 );
+                if( ref( $o ) eq "HASH" || ref( $o ) eq "ARRAY" ) {
+                    $ret .= objectToString( $o, $indent+1 ) . "\n";
+                } else {
+                    if( defined( $o )) {
+                        $ret .= objectToString( $o, $indent+1 ) . "\n";
+                    } else {
+                        $ret .= "<<undef>>\n";
+                    }
+                }
+            }
+        }
+        $ret .= indent( $indent ) . "}\n";
+
+    } elsif( $realtype eq "HASH" ) {
+        $ret .= ref( $obj ) . " {\n";
+        foreach my $k ( keys %{$obj} ) {
+            $ret .= indent( $indent+1 );
+            $ret .= sprintf( "%-32s => %s\n", $k, objectToString( $obj->{$k}, $indent+1 ));
+        }
+        $ret .= indent( $indent ) . "}";
+    } else {
+        $ret .= $obj;
+    }
+    return $ret;
+}
+
+#####
+# indent so many times
+sub indent {
+    my $indent = shift;
+
+    $indent = 0 unless( defined( $indent ));
+    my $ret = '';
+    for( my $i=0 ; $i<$indent ; ++$i ) {
+        $ret .= '    ';
+    }
+    return $ret;
+}
+
+
+if ($auth->auth) {
+	print $session_key;
+	#my $sql = qq(SELECT id FROM bw_xauth_session WEERE session_key=?);
+	#my $rv = $DBH->selectrow_hashref($sql, undef, $session_key);
+	print objectToString($auth->get_session($session_key));
+	#print $session_key;
+#	print $ss->{id};
+	print "~".$auth->id();
+  	#$auth->del_session($session_key);
+  	#print $q->redirect("mysessions.cgi");
+} else {
+  	#print $q->redirect("mysessions.cgi");
+}
+
+exit;

--- a/board/skin/default/mysessions.tmpl
+++ b/board/skin/default/mysessions.tmpl
@@ -1,0 +1,42 @@
+<tmpl_include _html_header.tmpl>
+<body class="<tmpl_if skin><tmpl_var skin></tmpl_if> <tmpl_if a_read>anonymous</tmpl_if>">
+<tmpl_include _header.tmpl>
+
+<div class="top-head">
+<h1><a href="mysessions.cgi">현재 접속 중인 기기 보기</a></h1>
+<span class="owner">: <tmpl_include _name_id.tmpl></span>
+<span class="breadcrumb"><tmpl_include _breadcrumb.tmpl></span>
+<tmpl_var ua>
+</div>
+
+<!-- LIST -->
+<div class="visualClear" style="height: 20px;"></div>
+
+<ul class="article head">
+<li class="button"><a href="bookmark.cgi" accesskey="b">즐겨찾기</a></li>
+<li class="button separator" id="article-<tmpl_var article_id>"><a>&nbsp;</a></li>
+</ul>
+
+<div class="article-list wrapper">
+<ul class="article-list head">
+  <li class="article">location</li>
+  <li class="comment">device</li>
+  <li class="date">date</li>
+</ul>
+<tmpl_loop sessions>
+<ul class="article-list">
+  <li><tmpl_var ip_address></li>
+  <li><tmpl_var user_agent></li>
+  <li class="date"><span title=""><tmpl_var created></span></li>
+  <li class=""><a href="remove_session.cgi?session_key=<tmpl_var session_key>">x</a></li>
+</ul>
+</tmpl_loop>
+
+</div><!-- article-list wrapper -->
+
+<ul class="article head">
+<li class="button"><a href="bookmark.cgi">즐겨찾기</a></li>
+<li class="button separator" id="article-<tmpl_var article_id>"><a>&nbsp;</a></li>
+</ul>
+
+<tmpl_include _footer.tmpl>


### PR DESCRIPTION
Preserves the **session-management** feature that was living untracked on the production box — on its own branch (not `main`) because it's incomplete.

- `board/mysessions.cgi` — "my active devices" list (IP geolocation + user agent). **The hardcoded MaxMind key was redacted**; wire creds from config before enabling.
- `board/remove_session.cgi` — session revoke, currently a **stub** (`del_session` is commented out; it only prints debug output).
- `board/skin/default/mysessions.tmpl`.

**Not ready to merge** — tracked here so the work isn't lost. To finish: implement revocation, and source GeoIP creds from config (or switch to offline GeoLite2, no API key), then wire into navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
