### PR TITLE
Give 경력 its own row on edit.cgi

### DIFF
--- a/user/edit.cgi
+++ b/user/edit.cgi
@@ -124,7 +124,10 @@ if ($uid) {
             }
         }
     }
-    $ui->tparam(profile=>[$user->get_user($uid)]);
+    my $p = $user->get_user($uid);
+    # own edit page: always show own careers (profile.cgi gates viewers, not owners)
+    $$p{career} = $user->get_career($uid);
+    $ui->tparam(profile=>[$p]);
     $ui->tparam(has_affiliation=>$user->has_affiliation($auth->uid));
     $ui->tparam(has_phone=>$user->has_phone($auth->uid));
 }

--- a/user/skin/default/edit.tmpl
+++ b/user/skin/default/edit.tmpl
@@ -202,7 +202,18 @@
         (<tmpl_var type_brief>) <a href="school.cgi?type=<tmpl_var type>&school_id=<tmpl_var school_id>" title="<tmpl_var school>"><tmpl_var school_short></a>, <tmpl_var department><tmpl_if advisors> (지도교수: <a  href="school.cgi?type=<tmpl_var type>&school_id=<tmpl_var school_id>" title="<tmpl_var school>"><tmpl_var advisors></a>)</tmpl_if> [<tmpl_var start_date>~<tmpl_var end_date><tmpl_if status>/<tmpl_var status_brief></tmpl_if>]<tmpl_unless __last__><br></tmpl_unless>
             </tmpl_loop>
         </tmpl_if>
-    [<a href="degree.cgi">추가/변경</a>] [<a href="career.cgi">경력 추가/변경</a>]
+    [<a href="degree.cgi">추가/변경</a>]
+    </td>
+</tr>
+<tr>
+    <td class="lhead" nowrap>경력</td>
+    <td class="iteml">
+        <tmpl_if career>
+            <tmpl_loop career>
+        (<tmpl_var type_brief>) <tmpl_var organization>, <tmpl_var position> [<tmpl_var start_date>~<tmpl_var end_date>]<tmpl_unless __last__><br></tmpl_unless>
+            </tmpl_loop>
+        </tmpl_if>
+    [<a href="career.cgi">추가/변경</a>]
     </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What

On /user/edit.cgi the career entry point was a small link tucked into the 학위 row. 경력 now gets its own row, mirroring how 학위 works: the user's careers are listed (same rendering as profile.cgi) followed by the [추가/변경] link to career.cgi.

- `user/edit.cgi`: pass `get_career($uid)` into the template, like profile.cgi does. Own edit page → no reciprocity gate (that gate is for viewing others).
- `user/skin/default/edit.tmpl`: new 경력 `<tr>` after 학위; the piggybacked link removed from the 학위 row.

## Verified (local Docker harness, root login)

Edit page shows the new 경력 row listing all 3 seeded careers — `(재직) 삼성전자, 책임연구원 [2020-03~현재]` etc. — with working 추가/변경 link; 학위 row back to just its own link. `perl -c` clean.

## Deploy note

Code + template only, no schema change, no restart needed (Registry picks up the .cgi by mtime; templates are mtime-revalidated). Just `git pull` on the deploy tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)