### PR TITLE
Fix 내가 쓴 글/짧은답글 pagination and search2 page-nav 404

### DIFF
--- a/board/myarticle.cgi
+++ b/board/myarticle.cgi
@@ -84,11 +84,15 @@ $t->param(total=>$articles);
 # The board list page (read.cgi's p=) this article appears on — pages are
 # reverse-numbered (tot_page = newest), matching get_tot_page/get_start in
 # Bawi::Board; read.cgi clamps if the denormalized c.articles has drifted.
+# CAST ... AS SIGNED: c.articles/c.article_per_page are UNSIGNED, so if the
+# counter has drifted low the CEIL-FLOOR difference goes negative and an
+# unsigned subtraction raises ER_DATA_OUT_OF_RANGE (1690) instead of letting
+# GREATEST clamp it — the SIGNED cast keeps the drift case a clamp, not a 500.
 my $board_page = qq(IF(c.article_per_page > 0,
-                       GREATEST(1, CEIL(c.articles / c.article_per_page) -
-                                   FLOOR((SELECT count(*) FROM bw_xboard_header as h
+                       GREATEST(1, CAST(CEIL(c.articles / c.article_per_page) AS SIGNED) -
+                                   CAST(FLOOR((SELECT count(*) FROM bw_xboard_header as h
                                           WHERE h.board_id=a.board_id && h.article_id > a.article_id)
-                                         / c.article_per_page)),
+                                         / c.article_per_page) AS SIGNED)),
                        1) as page);
 
 if ($board_id) {

--- a/board/myarticle.cgi
+++ b/board/myarticle.cgi
@@ -45,8 +45,8 @@ my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
 my $p = $q->param('p');
-my $page = $p || $tot_page || 1;
-$page = $tot_page < $page ? $tot_page : $page;
+my $page = $p;
+$page = $tot_page unless ($page && $page =~ /^\d+$/ && $page <= $tot_page);
 
 my $start_limit = ($tot_page - $page) * $article_per_page;
 
@@ -79,6 +79,17 @@ $t->param(first_page=>$first_page);
 $t->param(last_page=>$last_page);
 $t->param(pages=>\@pages);
 $t->param(p=>$p);
+$t->param(total=>$articles);
+
+# The board list page (read.cgi's p=) this article appears on — pages are
+# reverse-numbered (tot_page = newest), matching get_tot_page/get_start in
+# Bawi::Board; read.cgi clamps if the denormalized c.articles has drifted.
+my $board_page = qq(IF(c.article_per_page > 0,
+                       GREATEST(1, CEIL(c.articles / c.article_per_page) -
+                                   FLOOR((SELECT count(*) FROM bw_xboard_header as h
+                                          WHERE h.board_id=a.board_id && h.article_id > a.article_id)
+                                         / c.article_per_page)),
+                       1) as page);
 
 if ($board_id) {
 $sql = qq(SELECT a.board_id, a.article_id,
@@ -86,10 +97,11 @@ $sql = qq(SELECT a.board_id, a.article_id,
                  IF( a.created + INTERVAL 180 DAY > now(), DATE_FORMAT(a.created, '%m/%d'), DATE_FORMAT(a.created, '%y/%m/%d') ) as created,
                  DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,
                  a.count, a.recom, a.scrap, a.comments, a.has_attach,
-                 a.has_poll, $page as page,
+                 a.has_poll, $board_page,
                  c.title as board_title
-                 FROM bw_xboard_header as a, bw_xboard_board as c
-                 WHERE a.board_id=c.board_id && a.uid=? && a.board_id=? 
+                 FROM bw_xboard_header as a
+                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id
+                 WHERE a.uid=? && a.board_id=?
                  ORDER BY a.article_id DESC
 		  LIMIT $start_limit, $article_per_page);
   $rv = $DBH->selectall_hashref($sql, "article_id", undef, $uid, $board_id);
@@ -100,10 +112,11 @@ $sql = qq(SELECT a.board_id, a.article_id,
                  IF( a.created + INTERVAL 180 DAY > now(), DATE_FORMAT(a.created, '%m/%d'), DATE_FORMAT(a.created, '%y/%m/%d') ) as created,
                  DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,
                  a.count, a.recom, a.scrap, a.comments, a.has_attach,
-                 a.has_poll, $page as page,
+                 a.has_poll, $board_page,
                  c.title as board_title
-                 FROM bw_xboard_header as a, bw_xboard_board as c
-                 WHERE a.board_id=c.board_id && a.uid=?
+                 FROM bw_xboard_header as a
+                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id
+                 WHERE a.uid=?
                  ORDER BY a.article_id DESC
 		  LIMIT $start_limit, $article_per_page);
   $rv = $DBH->selectall_hashref($sql, "article_id", undef, $uid);

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -80,16 +80,25 @@ $t->param(last_page=>$last_page);
 $t->param(pages=>\@pages);
 $t->param(p=>$p);
 $t->param(total=>$articles);
+# cur_page = this my-comments listing page (reverse-numbered like the board).
+# The delete link routes through comment.cgi, which redirects to
+# mycomment.cgi?p=<this>, so it must carry the listing page, NOT the per-row
+# board page (that one is `page`, used only by the read link).
+$t->param(cur_page=>$page);
 
 # The board list page (read.cgi's p=) the comment's article appears on —
 # pages are reverse-numbered (tot_page = newest), matching get_tot_page/
 # get_start in Bawi::Board. The templates always forwarded p=<tmpl_var page>,
 # but no page column was ever selected, so the link carried an empty p.
+# CAST ... AS SIGNED: c.articles/c.article_per_page are UNSIGNED, so if the
+# counter has drifted low the CEIL-FLOOR difference goes negative and an
+# unsigned subtraction raises ER_DATA_OUT_OF_RANGE (1690) instead of letting
+# GREATEST clamp it — the SIGNED cast keeps the drift case a clamp, not a 500.
 my $board_page = qq(IF(c.article_per_page > 0,
-                       GREATEST(1, CEIL(c.articles / c.article_per_page) -
-                                   FLOOR((SELECT count(*) FROM bw_xboard_header as h
+                       GREATEST(1, CAST(CEIL(c.articles / c.article_per_page) AS SIGNED) -
+                                   CAST(FLOOR((SELECT count(*) FROM bw_xboard_header as h
                                           WHERE h.board_id=a.board_id && h.article_id > a.article_id)
-                                         / c.article_per_page)),
+                                         / c.article_per_page) AS SIGNED)),
                        1) as page);
 
 if ($board_id) {

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -84,7 +84,12 @@ $t->param(total=>$articles);
 # The delete link routes through comment.cgi, which redirects to
 # mycomment.cgi?p=<this>, so it must carry the listing page, NOT the per-row
 # board page (that one is `page`, used only by the read link).
-$t->param(cur_page=>$page);
+# But comment.cgi's redirect drops the bid, so when this listing is itself
+# bid-filtered the filtered page number would be applied to the UNFILTERED
+# listing (a different, usually larger, page space) and land on the wrong
+# page. In the filtered case emit an empty p instead, which mycomment.cgi
+# then clamps to the newest page — the pre-existing behaviour for that flow.
+$t->param(cur_page=>$board_id ? '' : $page);
 
 # The board list page (read.cgi's p=) the comment's article appears on —
 # pages are reverse-numbered (tot_page = newest), matching get_tot_page/

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -45,8 +45,8 @@ my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
 my $p = $q->param('p');
-my $page = $p || $tot_page || 1;
-$page = $tot_page < $page ? $tot_page : $page;
+my $page = $p;
+$page = $tot_page unless ($page && $page =~ /^\d+$/ && $page <= $tot_page);
 
 my $start_limit = ($tot_page - $page) * $article_per_page;
 
@@ -79,6 +79,18 @@ $t->param(first_page=>$first_page);
 $t->param(last_page=>$last_page);
 $t->param(pages=>\@pages);
 $t->param(p=>$p);
+$t->param(total=>$articles);
+
+# The board list page (read.cgi's p=) the comment's article appears on —
+# pages are reverse-numbered (tot_page = newest), matching get_tot_page/
+# get_start in Bawi::Board. The templates always forwarded p=<tmpl_var page>,
+# but no page column was ever selected, so the link carried an empty p.
+my $board_page = qq(IF(c.article_per_page > 0,
+                       GREATEST(1, CEIL(c.articles / c.article_per_page) -
+                                   FLOOR((SELECT count(*) FROM bw_xboard_header as h
+                                          WHERE h.board_id=a.board_id && h.article_id > a.article_id)
+                                         / c.article_per_page)),
+                       1) as page);
 
 if ($board_id) {
   $sql = qq(SELECT a.board_id as board_id, a.article_id as article_id, a.comment_id as comment_id,                  
@@ -87,11 +99,12 @@ if ($board_id) {
                  IF( a.created + INTERVAL 180 DAY > now(),                      
                      DATE_FORMAT(a.created, '%m/%d'),
                      DATE_FORMAT(a.created, '%y/%m/%d') ) as created,
-                 DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,                  
+                 DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,
+                 $board_page,
                  c.title as board_title
-                 FROM bw_xboard_comment as a 
-                 LEFT JOIN bw_xboard_header as b ON a.article_id=b.article_id 
-                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id 
+                 FROM bw_xboard_comment as a
+                 LEFT JOIN bw_xboard_header as b ON a.article_id=b.article_id
+                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id
                  WHERE a.uid=? && a.board_id=?
                  ORDER BY a.comment_id DESC
 				 LIMIT $start_limit, $article_per_page);
@@ -105,11 +118,12 @@ if ($board_id) {
                  IF( a.created + INTERVAL 180 DAY > now(),                      
                      DATE_FORMAT(a.created, '%m/%d'),
                      DATE_FORMAT(a.created, '%y/%m/%d') ) as created,
-                 DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,                  
+                 DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,
+                 $board_page,
                  c.title as board_title
-                 FROM bw_xboard_comment as a 
-                 LEFT JOIN bw_xboard_header as b ON a.article_id=b.article_id 
-                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id 
+                 FROM bw_xboard_comment as a
+                 LEFT JOIN bw_xboard_header as b ON a.article_id=b.article_id
+                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id
                  WHERE a.uid=?
                  ORDER BY a.comment_id DESC
 				 LIMIT $start_limit, $article_per_page);

--- a/board/skin/default/myarticle.tmpl
+++ b/board/skin/default/myarticle.tmpl
@@ -4,7 +4,7 @@
 
 <div class="top-head">
 <h1><a href="myarticle.cgi">내가 쓴 글 보기</a></h1>
-<span class="owner">: <tmpl_include _name_id.tmpl></span>
+<span class="owner">: <tmpl_include _name_id.tmpl> (총 <tmpl_var total>건)</span>
 <span class="breadcrumb"><tmpl_include _breadcrumb.tmpl></span>
 </div>
 

--- a/board/skin/default/mycomment.tmpl
+++ b/board/skin/default/mycomment.tmpl
@@ -4,7 +4,7 @@
 
 <div class="top-head">
 <h1><a href="mycomment.cgi">내가 쓴 짧은 답글 보기</a></h1>
-<span class="owner">: <tmpl_include _name_id.tmpl></span>
+<span class="owner">: <tmpl_include _name_id.tmpl> (총 <tmpl_var total>건)</span>
 <span class="breadcrumb"><tmpl_include _breadcrumb.tmpl></span>
 </div>
 

--- a/board/skin/default/mycomment.tmpl
+++ b/board/skin/default/mycomment.tmpl
@@ -40,7 +40,7 @@
   <li class="comment"><a href="read.cgi?bid=<tmpl_var board_id>;aid=<tmpl_var article_id>;p=<tmpl_var page>#c<tmpl_var comment_no>"><tmpl_var comment></a></li>
   <li class="date"><span title="<tmpl_var created_str>"><tmpl_var created></span></li>
   <li class="delete">
-  <a href="comment.cgi?action=delete&bid=<tmpl_var board_id>&aid=<tmpl_var article_id>&cid=<tmpl_var comment_id>&p=<tmpl_var page><tmpl_if img>&img=1</tmpl_if>&redirect=mycomment" onclick="return window.confirm('Delete this comment?');">x</a></li>
+  <a href="comment.cgi?action=delete&bid=<tmpl_var board_id>&aid=<tmpl_var article_id>&cid=<tmpl_var comment_id>&p=<tmpl_var cur_page><tmpl_if img>&img=1</tmpl_if>&redirect=mycomment" onclick="return window.confirm('Delete this comment?');">x</a></li>
 </ul>
 </tmpl_loop>
 </div><!-- article-list wrapper -->

--- a/main/skin/default/_search2_page_nav.tmpl
+++ b/main/skin/default/_search2_page_nav.tmpl
@@ -1,22 +1,22 @@
 <ul class="page-nav">
 <tmpl_var page>
 <tmpl_if last_page>
-<li><a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var last_page>">[<tmpl_var last_page>]</a>...</li>
+<li><a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var last_page>">[<tmpl_var last_page>]</a>...</li>
 </tmpl_if>
 <tmpl_if prev_page>
-<li><a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var prev_page>">[<tmpl_var T_PREV>]</a></li>
+<li><a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var prev_page>">[<tmpl_var T_PREV>]</a></li>
 </tmpl_if>
 <tmpl_loop pages>
   <tmpl_if current>
 <li class="current"><tmpl_var page></li>
   <tmpl_else>
-<li><a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var page>"><tmpl_var page></a></li>
+<li><a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var page>"><tmpl_var page></a></li>
   </tmpl_if>
 </tmpl_loop>
 <tmpl_if next_page>
-<li><a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var next_page>">[<tmpl_var T_NEXT>]</a></li>
+<li><a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var next_page>">[<tmpl_var T_NEXT>]</a></li>
 </tmpl_if>
 <tmpl_if first_page>
-<li>...<a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var first_page>">[1]</a></li>
+<li>...<a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var first_page>">[1]</a></li>
 </tmpl_if>
 </ul>


### PR DESCRIPTION
Pagination fixes for the special "my" pages, as requested.

## What was broken

1. **Article links carried a bogus `p`.** `myarticle.cgi` injected *its own* reverse page number (1–3 for a typical user) as `read.cgi`'s `p`; `mycomment.tmpl` forwarded `p=<tmpl_var page>` but the SQL never selected a `page` column, so the link always carried an empty `p`. Either way, clicking through showed the article above an unrelated list page.
2. **`p=0` / garbage `p` rendered an empty page** — only the upper bound was clamped (`read.cgi` clamps both; these two didn't).
3. **Phantom trailing pages in `myarticle.cgi`** — the count query ignored the board join while the listing INNER JOINed `bw_xboard_board`, so articles in orphaned boards inflated `tot_page` past the real rows.
4. **No total shown** on either page.
5. **`_search2_page_nav.tmpl` linked `search3.cgi`** — which doesn't exist, so article-search pagination past the current 10-page window 404'd. (search2 itself stays menu-hidden, per policy.)

## The fixes

- Both listings now compute the article's **real board list page** in SQL — `tot_page - floor(rank/per_page)` using the same reverse numbering as `get_tot_page`/`get_start`, with `GREATEST(1, ...)`/`IF(per_page>0, ..., 1)` guards so orphaned boards or drifted counters degrade to a clamped-but-rendering `read.cgi` (which re-clamps `p` anyway).
- `p` validated exactly like `read.cgi` (`^\d+$` + range), myarticle listing switched to LEFT JOIN to agree with its count, and both pages show `(총 N건)`.
- `search3.cgi` → `search2.cgi` (5 occurrences).

Left alone deliberately: the hardcoded 16/page (vs boards' 15) and the reverse-numbered `[이전]/[다음]` semantics — behavior-neutral choices, flagged in case you want them harmonized separately.

## Verification (Docker mirror, seeded: 320 articles/320 comments over 6 boards)

- In-container `perl -c` on both CGIs.
- As `testuser23` (46 articles): `(총 46건)` renders; `p=0` now returns a full 16-row page (previously empty).
- **Computed pages cross-checked against read.cgi itself**: board 6 (25 articles, 15/page) — links said `aid=318→p=2`, `aid=311→p=2`, `aid=304→p=1`, and fetching `read.cgi?bid=6;p=2` / `p=1` shows exactly those articles on those list pages. `mycomment.cgi` links now carry the same valid `p` with their `#c<n>` anchors.
- Mirror restored to `career-v3.2` + graceful restart afterward.

Code-only; no migration. Deploy = `git pull` + graceful restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
