### PR TITLE
Auto-embed .svg URLs as <img> in bodies and comments

### DIFF
--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -2756,7 +2756,7 @@ sub make_hyperlink {
         $shorten = join("", $u[1], $u[2], $u[3] ? "../" : "", $u[4], $u[5] ? "?.." : "") if length $shorten > 65;
         $shorten = join("", $u[1], $u[2], ($u[3] || $u[4] || $u[5] ) ? "..." : "") if length $shorten > 70;
       };
-      m! \.(?:jpg|jpeg|gif|png) $ !iogx and
+      m! \.(?:jpg|jpeg|gif|png|svg) $ !iogx and
         return qq(<a href="$src" rel="lightbox[embedded-$aid]" title="$title [$1] by $name ($id)" class="auto"><img src="$src" alt="$_"/></a>);
       # Internet Explorer uses the <object> tag, while Firefox, Safari, Chrome, and Opera use the <embed> tag.
       m! \.(?:swf|flv|mp4) $ !iox and $domain =~ m|bawi\.org/$|o and $page eq "attach.cgi" and


### PR DESCRIPTION
One-line follow-up to #7, as planned in the improvements review: `make_hyperlink`'s image branch (`lib/Bawi/Board.pm:2759`) now recognizes `.svg` alongside jpg/jpeg/gif/png, so pasted `attach.cgi?atid=…;name=/foo.svg` links (and any URL ending in `.svg`) auto-convert to `<img>` in **both article bodies and comments** — the two share this one function.

**Why it's safe:** attach.cgi has served SVG inline with `Content-Security-Policy: sandbox` + nosniff since #7, SVG referenced via `<img>` cannot execute script in any browser, and `is_img` stays `'n'` (SVG never touches ImageMagick — the ImageTragick guard is unchanged).

**Not included:** the independent legacy `make_hyperlink` copies for signatures (`Bawi::User`) and notes (`Bawi::Main::Note`) — they're `http://`-only and also lack `jpeg`; left for a separate decision.

**Verification (Docker mirror):** in-container `perl -c` on Board.pm; posted a comment containing an `attach.cgi?atid=…;name=/panel.svg` URL, a case-test `.SVG` URL, and a `.png` regression URL — all three rendered as `<img>` in read.cgi output. Test comment removed and mirror restored afterward.

Code-only; deploy = `git pull` + graceful restart (mod_perl caches Board.pm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
