### PR TITLE
Validate reflected page/bid/keyword params (XSS hardening sweep)

### DIFF
--- a/board/myarticle.cgi
+++ b/board/myarticle.cgi
@@ -46,7 +46,7 @@ my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
 my $p = $q->param('p') || '';
-$p = '' unless $p =~ /^\d+$/;   # reflected via the p tparam
+$p = '' unless $p =~ /^\d+$/;   # no p sink in this page's templates; kept numeric so the $page arithmetic below stays sane
 my $page = $p;
 $page = $tot_page unless ($page && $page <= $tot_page);
 

--- a/board/myarticle.cgi
+++ b/board/myarticle.cgi
@@ -27,6 +27,7 @@ if ($auth->auth) {
 }
 
 my $board_id = $q->param('bid') || 0;
+$board_id = 0 unless $board_id =~ /^\d+$/;   # reflected into the url tparam (page-nav hrefs)
 my $sql;
 my $rv;
 
@@ -44,9 +45,10 @@ my $page_per_page = 10;
 my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
-my $p = $q->param('p');
+my $p = $q->param('p') || '';
+$p = '' unless $p =~ /^\d+$/;   # reflected via the p tparam
 my $page = $p;
-$page = $tot_page unless ($page && $page =~ /^\d+$/ && $page <= $tot_page);
+$page = $tot_page unless ($page && $page <= $tot_page);
 
 my $start_limit = ($tot_page - $page) * $article_per_page;
 

--- a/board/myarticle.cgi
+++ b/board/myarticle.cgi
@@ -84,11 +84,15 @@ $t->param(total=>$articles);
 # The board list page (read.cgi's p=) this article appears on — pages are
 # reverse-numbered (tot_page = newest), matching get_tot_page/get_start in
 # Bawi::Board; read.cgi clamps if the denormalized c.articles has drifted.
+# CAST ... AS SIGNED: c.articles/c.article_per_page are UNSIGNED, so if the
+# counter has drifted low the CEIL-FLOOR difference goes negative and an
+# unsigned subtraction raises ER_DATA_OUT_OF_RANGE (1690) instead of letting
+# GREATEST clamp it — the SIGNED cast keeps the drift case a clamp, not a 500.
 my $board_page = qq(IF(c.article_per_page > 0,
-                       GREATEST(1, CEIL(c.articles / c.article_per_page) -
-                                   FLOOR((SELECT count(*) FROM bw_xboard_header as h
+                       GREATEST(1, CAST(CEIL(c.articles / c.article_per_page) AS SIGNED) -
+                                   CAST(FLOOR((SELECT count(*) FROM bw_xboard_header as h
                                           WHERE h.board_id=a.board_id && h.article_id > a.article_id)
-                                         / c.article_per_page)),
+                                         / c.article_per_page) AS SIGNED)),
                        1) as page);
 
 if ($board_id) {

--- a/board/myarticle.cgi
+++ b/board/myarticle.cgi
@@ -45,8 +45,8 @@ my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
 my $p = $q->param('p');
-my $page = $p || $tot_page || 1;
-$page = $tot_page < $page ? $tot_page : $page;
+my $page = $p;
+$page = $tot_page unless ($page && $page =~ /^\d+$/ && $page <= $tot_page);
 
 my $start_limit = ($tot_page - $page) * $article_per_page;
 
@@ -79,6 +79,17 @@ $t->param(first_page=>$first_page);
 $t->param(last_page=>$last_page);
 $t->param(pages=>\@pages);
 $t->param(p=>$p);
+$t->param(total=>$articles);
+
+# The board list page (read.cgi's p=) this article appears on — pages are
+# reverse-numbered (tot_page = newest), matching get_tot_page/get_start in
+# Bawi::Board; read.cgi clamps if the denormalized c.articles has drifted.
+my $board_page = qq(IF(c.article_per_page > 0,
+                       GREATEST(1, CEIL(c.articles / c.article_per_page) -
+                                   FLOOR((SELECT count(*) FROM bw_xboard_header as h
+                                          WHERE h.board_id=a.board_id && h.article_id > a.article_id)
+                                         / c.article_per_page)),
+                       1) as page);
 
 if ($board_id) {
 $sql = qq(SELECT a.board_id, a.article_id,
@@ -86,10 +97,11 @@ $sql = qq(SELECT a.board_id, a.article_id,
                  IF( a.created + INTERVAL 180 DAY > now(), DATE_FORMAT(a.created, '%m/%d'), DATE_FORMAT(a.created, '%y/%m/%d') ) as created,
                  DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,
                  a.count, a.recom, a.scrap, a.comments, a.has_attach,
-                 a.has_poll, $page as page,
+                 a.has_poll, $board_page,
                  c.title as board_title
-                 FROM bw_xboard_header as a, bw_xboard_board as c
-                 WHERE a.board_id=c.board_id && a.uid=? && a.board_id=? 
+                 FROM bw_xboard_header as a
+                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id
+                 WHERE a.uid=? && a.board_id=?
                  ORDER BY a.article_id DESC
 		  LIMIT $start_limit, $article_per_page);
   $rv = $DBH->selectall_hashref($sql, "article_id", undef, $uid, $board_id);
@@ -100,10 +112,11 @@ $sql = qq(SELECT a.board_id, a.article_id,
                  IF( a.created + INTERVAL 180 DAY > now(), DATE_FORMAT(a.created, '%m/%d'), DATE_FORMAT(a.created, '%y/%m/%d') ) as created,
                  DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,
                  a.count, a.recom, a.scrap, a.comments, a.has_attach,
-                 a.has_poll, $page as page,
+                 a.has_poll, $board_page,
                  c.title as board_title
-                 FROM bw_xboard_header as a, bw_xboard_board as c
-                 WHERE a.board_id=c.board_id && a.uid=?
+                 FROM bw_xboard_header as a
+                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id
+                 WHERE a.uid=?
                  ORDER BY a.article_id DESC
 		  LIMIT $start_limit, $article_per_page);
   $rv = $DBH->selectall_hashref($sql, "article_id", undef, $uid);

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -46,7 +46,7 @@ my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
 my $p = $q->param('p') || '';
-$p = '' unless $p =~ /^\d+$/;   # reflected via the p tparam
+$p = '' unless $p =~ /^\d+$/;   # no p sink in this page's templates; kept numeric so the $page arithmetic below stays sane
 my $page = $p;
 $page = $tot_page unless ($page && $page <= $tot_page);
 

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -80,16 +80,25 @@ $t->param(last_page=>$last_page);
 $t->param(pages=>\@pages);
 $t->param(p=>$p);
 $t->param(total=>$articles);
+# cur_page = this my-comments listing page (reverse-numbered like the board).
+# The delete link routes through comment.cgi, which redirects to
+# mycomment.cgi?p=<this>, so it must carry the listing page, NOT the per-row
+# board page (that one is `page`, used only by the read link).
+$t->param(cur_page=>$page);
 
 # The board list page (read.cgi's p=) the comment's article appears on —
 # pages are reverse-numbered (tot_page = newest), matching get_tot_page/
 # get_start in Bawi::Board. The templates always forwarded p=<tmpl_var page>,
 # but no page column was ever selected, so the link carried an empty p.
+# CAST ... AS SIGNED: c.articles/c.article_per_page are UNSIGNED, so if the
+# counter has drifted low the CEIL-FLOOR difference goes negative and an
+# unsigned subtraction raises ER_DATA_OUT_OF_RANGE (1690) instead of letting
+# GREATEST clamp it — the SIGNED cast keeps the drift case a clamp, not a 500.
 my $board_page = qq(IF(c.article_per_page > 0,
-                       GREATEST(1, CEIL(c.articles / c.article_per_page) -
-                                   FLOOR((SELECT count(*) FROM bw_xboard_header as h
+                       GREATEST(1, CAST(CEIL(c.articles / c.article_per_page) AS SIGNED) -
+                                   CAST(FLOOR((SELECT count(*) FROM bw_xboard_header as h
                                           WHERE h.board_id=a.board_id && h.article_id > a.article_id)
-                                         / c.article_per_page)),
+                                         / c.article_per_page) AS SIGNED)),
                        1) as page);
 
 if ($board_id) {

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -27,6 +27,7 @@ if ($auth->auth) {
 }
 
 my $board_id = $q->param('bid') || 0;
+$board_id = 0 unless $board_id =~ /^\d+$/;   # reflected into the url tparam (page-nav hrefs)
 my $sql;
 my $rv;
 
@@ -44,9 +45,10 @@ my $page_per_page = 10;
 my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
-my $p = $q->param('p');
+my $p = $q->param('p') || '';
+$p = '' unless $p =~ /^\d+$/;   # reflected via the p tparam
 my $page = $p;
-$page = $tot_page unless ($page && $page =~ /^\d+$/ && $page <= $tot_page);
+$page = $tot_page unless ($page && $page <= $tot_page);
 
 my $start_limit = ($tot_page - $page) * $article_per_page;
 

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -84,7 +84,12 @@ $t->param(total=>$articles);
 # The delete link routes through comment.cgi, which redirects to
 # mycomment.cgi?p=<this>, so it must carry the listing page, NOT the per-row
 # board page (that one is `page`, used only by the read link).
-$t->param(cur_page=>$page);
+# But comment.cgi's redirect drops the bid, so when this listing is itself
+# bid-filtered the filtered page number would be applied to the UNFILTERED
+# listing (a different, usually larger, page space) and land on the wrong
+# page. In the filtered case emit an empty p instead, which mycomment.cgi
+# then clamps to the newest page — the pre-existing behaviour for that flow.
+$t->param(cur_page=>$board_id ? '' : $page);
 
 # The board list page (read.cgi's p=) the comment's article appears on —
 # pages are reverse-numbered (tot_page = newest), matching get_tot_page/

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -45,8 +45,8 @@ my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
 my $p = $q->param('p');
-my $page = $p || $tot_page || 1;
-$page = $tot_page < $page ? $tot_page : $page;
+my $page = $p;
+$page = $tot_page unless ($page && $page =~ /^\d+$/ && $page <= $tot_page);
 
 my $start_limit = ($tot_page - $page) * $article_per_page;
 
@@ -79,6 +79,18 @@ $t->param(first_page=>$first_page);
 $t->param(last_page=>$last_page);
 $t->param(pages=>\@pages);
 $t->param(p=>$p);
+$t->param(total=>$articles);
+
+# The board list page (read.cgi's p=) the comment's article appears on —
+# pages are reverse-numbered (tot_page = newest), matching get_tot_page/
+# get_start in Bawi::Board. The templates always forwarded p=<tmpl_var page>,
+# but no page column was ever selected, so the link carried an empty p.
+my $board_page = qq(IF(c.article_per_page > 0,
+                       GREATEST(1, CEIL(c.articles / c.article_per_page) -
+                                   FLOOR((SELECT count(*) FROM bw_xboard_header as h
+                                          WHERE h.board_id=a.board_id && h.article_id > a.article_id)
+                                         / c.article_per_page)),
+                       1) as page);
 
 if ($board_id) {
   $sql = qq(SELECT a.board_id as board_id, a.article_id as article_id, a.comment_id as comment_id,                  
@@ -87,11 +99,12 @@ if ($board_id) {
                  IF( a.created + INTERVAL 180 DAY > now(),                      
                      DATE_FORMAT(a.created, '%m/%d'),
                      DATE_FORMAT(a.created, '%y/%m/%d') ) as created,
-                 DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,                  
+                 DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,
+                 $board_page,
                  c.title as board_title
-                 FROM bw_xboard_comment as a 
-                 LEFT JOIN bw_xboard_header as b ON a.article_id=b.article_id 
-                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id 
+                 FROM bw_xboard_comment as a
+                 LEFT JOIN bw_xboard_header as b ON a.article_id=b.article_id
+                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id
                  WHERE a.uid=? && a.board_id=?
                  ORDER BY a.comment_id DESC
 				 LIMIT $start_limit, $article_per_page);
@@ -105,11 +118,12 @@ if ($board_id) {
                  IF( a.created + INTERVAL 180 DAY > now(),                      
                      DATE_FORMAT(a.created, '%m/%d'),
                      DATE_FORMAT(a.created, '%y/%m/%d') ) as created,
-                 DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,                  
+                 DATE_FORMAT(a.created, '%Y/%m/%d (%a) %H:%i:%s') as created_str,
+                 $board_page,
                  c.title as board_title
-                 FROM bw_xboard_comment as a 
-                 LEFT JOIN bw_xboard_header as b ON a.article_id=b.article_id 
-                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id 
+                 FROM bw_xboard_comment as a
+                 LEFT JOIN bw_xboard_header as b ON a.article_id=b.article_id
+                 LEFT JOIN bw_xboard_board as c ON a.board_id=c.board_id
                  WHERE a.uid=?
                  ORDER BY a.comment_id DESC
 				 LIMIT $start_limit, $article_per_page);

--- a/board/search.cgi
+++ b/board/search.cgi
@@ -18,12 +18,12 @@ my $xb = new Bawi::Board(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
 $ui->tparam(HTMLTitle => "찾기");
 
 my ($keyword, $field) = map { $ui->cparam($_) || '' } qw(keyword field);
-$field = 'title' unless $field =~ /^(title|body|name|id)$/;
+my @field = qw(title body name id);
+$field = 'title' unless grep { $_ eq $field } @field;   # whitelist: single source of truth (also drives the radio loop below)
 $ui->tparam(keyword=>$ui->cgi->escapeHTML($keyword));   # reflected into the form's value attribute
 $ui->tparam(field=>$field);
 
 my @search_fields;
-my @field = qw(title body name id);
 foreach my $i (@field) {
     my $checked = $i eq $field ? 1 : 0;
     push @search_fields, { field=>$i, checked=>$checked };

--- a/board/search.cgi
+++ b/board/search.cgi
@@ -18,10 +18,10 @@ my $xb = new Bawi::Board(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
 $ui->tparam(HTMLTitle => "찾기");
 
 my ($keyword, $field) = map { $ui->cparam($_) || '' } qw(keyword field);
-$ui->tparam(keyword=>$keyword);
+$field = 'title' unless $field =~ /^(title|body|name|id)$/;
+$ui->tparam(keyword=>$ui->cgi->escapeHTML($keyword));   # reflected into the form's value attribute
 $ui->tparam(field=>$field);
 
-$field = 'title' unless $field; 
 my @search_fields;
 my @field = qw(title body name id);
 foreach my $i (@field) {

--- a/board/skin/default/myarticle.tmpl
+++ b/board/skin/default/myarticle.tmpl
@@ -4,7 +4,7 @@
 
 <div class="top-head">
 <h1><a href="myarticle.cgi">내가 쓴 글 보기</a></h1>
-<span class="owner">: <tmpl_include _name_id.tmpl></span>
+<span class="owner">: <tmpl_include _name_id.tmpl> (총 <tmpl_var total>건)</span>
 <span class="breadcrumb"><tmpl_include _breadcrumb.tmpl></span>
 </div>
 

--- a/board/skin/default/mycomment.tmpl
+++ b/board/skin/default/mycomment.tmpl
@@ -4,7 +4,7 @@
 
 <div class="top-head">
 <h1><a href="mycomment.cgi">내가 쓴 짧은 답글 보기</a></h1>
-<span class="owner">: <tmpl_include _name_id.tmpl></span>
+<span class="owner">: <tmpl_include _name_id.tmpl> (총 <tmpl_var total>건)</span>
 <span class="breadcrumb"><tmpl_include _breadcrumb.tmpl></span>
 </div>
 

--- a/board/skin/default/mycomment.tmpl
+++ b/board/skin/default/mycomment.tmpl
@@ -40,7 +40,7 @@
   <li class="comment"><a href="read.cgi?bid=<tmpl_var board_id>;aid=<tmpl_var article_id>;p=<tmpl_var page>#c<tmpl_var comment_no>"><tmpl_var comment></a></li>
   <li class="date"><span title="<tmpl_var created_str>"><tmpl_var created></span></li>
   <li class="delete">
-  <a href="comment.cgi?action=delete&bid=<tmpl_var board_id>&aid=<tmpl_var article_id>&cid=<tmpl_var comment_id>&p=<tmpl_var page><tmpl_if img>&img=1</tmpl_if>&redirect=mycomment" onclick="return window.confirm('Delete this comment?');">x</a></li>
+  <a href="comment.cgi?action=delete&bid=<tmpl_var board_id>&aid=<tmpl_var article_id>&cid=<tmpl_var comment_id>&p=<tmpl_var cur_page><tmpl_if img>&img=1</tmpl_if>&redirect=mycomment" onclick="return window.confirm('Delete this comment?');">x</a></li>
 </ul>
 </tmpl_loop>
 </div><!-- article-list wrapper -->

--- a/main/search2.cgi
+++ b/main/search2.cgi
@@ -15,7 +15,7 @@ unless ($auth->auth) {
 
 my ($type, $keyword, $page) = map { $ui->cparam($_) || '' } qw(type keyword page);
 $type = 'article' unless ($type);
-$page = '1' unless ($page =~ /^\d+$/);   # numeric only: reflected into page-nav hrefs
+$page = '1' unless ($page =~ /^[1-9]\d*\z/);   # positive integer only: rendered as bare text in _search2_page_nav.tmpl and feeds the SQL LIMIT offset
 
 if ($type && $type =~ /article|people|board/ && $keyword) {
 

--- a/main/search2.cgi
+++ b/main/search2.cgi
@@ -15,7 +15,7 @@ unless ($auth->auth) {
 
 my ($type, $keyword, $page) = map { $ui->cparam($_) || '' } qw(type keyword page);
 $type = 'article' unless ($type);
-$page = '1' unless ($page);
+$page = '1' unless ($page =~ /^\d+$/);   # numeric only: reflected into page-nav hrefs
 
 if ($type && $type =~ /article|people|board/ && $keyword) {
 

--- a/main/skin/default/_search2_page_nav.tmpl
+++ b/main/skin/default/_search2_page_nav.tmpl
@@ -1,22 +1,22 @@
 <ul class="page-nav">
 <tmpl_var page>
 <tmpl_if last_page>
-<li><a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var last_page>">[<tmpl_var last_page>]</a>...</li>
+<li><a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var last_page>">[<tmpl_var last_page>]</a>...</li>
 </tmpl_if>
 <tmpl_if prev_page>
-<li><a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var prev_page>">[<tmpl_var T_PREV>]</a></li>
+<li><a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var prev_page>">[<tmpl_var T_PREV>]</a></li>
 </tmpl_if>
 <tmpl_loop pages>
   <tmpl_if current>
 <li class="current"><tmpl_var page></li>
   <tmpl_else>
-<li><a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var page>"><tmpl_var page></a></li>
+<li><a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var page>"><tmpl_var page></a></li>
   </tmpl_if>
 </tmpl_loop>
 <tmpl_if next_page>
-<li><a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var next_page>">[<tmpl_var T_NEXT>]</a></li>
+<li><a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var next_page>">[<tmpl_var T_NEXT>]</a></li>
 </tmpl_if>
 <tmpl_if first_page>
-<li>...<a href="search3.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var first_page>">[1]</a></li>
+<li>...<a href="search2.cgi?keyword=<tmpl_var keyword>;type=<tmpl_var type>;page=<tmpl_var first_page>">[1]</a></li>
 </tmpl_if>
 </ul>


### PR DESCRIPTION
**Stacked on #9** — merge #9 first; this PR then collapses to the single sweep commit (4 files, +11/−7).

Deep-review of #9 flagged reflected-request-params as a systemic pre-existing pattern (not introduced by any recent PR). This is the dedicated hardening sweep. I grepped every `tparam`/`param` reflection across `board/`, `main/`, `user/`, `admin/` CGIs; these were the sinks that take unvalidated input:

| File | Param | Sink | Fix |
|---|---|---|---|
| `board/search.cgi` | `keyword` | `value="<tmpl_var keyword>"` in `_search_form.tmpl` — **attribute-breakout XSS, directly reachable** (`read.cgi` escapes the same variable; this standalone page didn't) | `escapeHTML` |
| `board/search.cgi` | `field` | tparam'd raw (unused by template today — landmine) | anchored whitelist `title\|body\|name\|id` |
| `board/myarticle.cgi`, `board/mycomment.cgi` | `bid` | `url` tparam → `_page_nav_special.tmpl` hrefs | forced numeric (else 0), same policy as `read.cgi` |
| `board/myarticle.cgi`, `board/mycomment.cgi` | `p` | `p` tparam | forced numeric (else empty) |
| `main/search2.cgi` | `page` | `_search2_page_nav.tmpl` hrefs (currently unreachable — article search sets no nav vars) | forced numeric (else 1) |

Everything else that reflects input already escapes or whitelists (`read.cgi` k/f, `main/search.cgi`/`user/search.cgi` keyword, `main/search2.cgi` keyword/type).

**Verification (Docker mirror, overlaid on #9's head):** in-container `perl -c` on all four; e2e as authenticated user — `keyword="><script>alert(1)</script>` renders fully entity-escaped inside the attribute; `bid="><script>` drops to the no-bid branch (nav hrefs carry no injected text); `p=<script>` reflects nothing; regressions: `bid=6` lists normally with `총 4건` and `bid=6` nav links, `keyword=test&field=body` renders `value="test"` with body radio checked. Mirror restored clean afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
