### PR TITLE
Harden session cookie (HttpOnly) + enforce anonboard gate server-side

### DIFF
--- a/board/boardcfg.cgi
+++ b/board/boardcfg.cgi
@@ -76,6 +76,10 @@ push @field, qw(seq gid article_per_page page_per_page
                g_comment m_comment a_comment); # if $is_root;
 my $updated = 0;
 foreach my $i (@field) {
+    # Enforce the anonboard gate server-side: line 62 only controls whether the
+    # UI renders the toggle. Without this, an owner could POST is_anonboard=1
+    # even when AllowAnonBoard is off (config gates visibility, not the write).
+    next if ($i eq 'is_anonboard' && !$allow_anon_board);
     my @val = $ui->cgi->param($i);
     my $val = pop (@val);
     $val =~ s/^\s+|\s+$//g if defined $val;

--- a/lib/Bawi/Auth.pm
+++ b/lib/Bawi/Auth.pm
@@ -54,6 +54,7 @@ sub new {
             -domain  => $cfg->SessionDomain,
             -path    => $OPT{session_path},
             -expires => $OPT{session_expires},
+            -httponly => 1,   # block document.cookie access -> session key not stealable via XSS
         }
             
     }, $class;


### PR DESCRIPTION
## Session-cookie & anonboard hardening (no deps, no user-visible change)

Two small server-side hardening fixes, verified on the Docker mirror.

### 1. `HttpOnly` on the session cookie (`lib/Bawi/Auth.pm`)
The session cookie was issued with `-name/-domain/-path/-expires` only. Adding
`-httponly => 1` stops client-side JavaScript from reading the session key via
`document.cookie`. Server-side session validation is unchanged — the browser
still sends the cookie — so login/logout/auth flow is unaffected.

Mirror-verified: `Set-Cookie: bawi_session=…; path=/; HttpOnly` on login as `root`.

### 2. Enforce the anonboard gate server-side (`board/boardcfg.cgi`)
`AllowAnonBoard` (line 62) gated only whether the UI rendered the anonboard
toggle; the field loop still accepted `is_anonboard` from the POST for any board
owner. A board owner could therefore flip their own board to anonymous with a
crafted request even when the config disallows it. The backend now honors the
same gate (`next if is_anonboard && !$allow_anon_board`). Long-standing (present
since the original import), not a regression.

### Verification
- `perl -c` clean (in-container) for both files.
- Mirror e2e: login as `root` → session cookie carries `HttpOnly`; anonboard
  guard verified by code-trace + syntax.
- No new dependency; no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
