### PR TITLE
MathJax in markdown mode; fenced code (prism), pipe tables, strikethrough

### DIFF
--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -18,9 +18,14 @@ my $href_strip   = 's/\shref\s*=\s*(["\'])\s*(?:javascript|data|vbscript)\s*:[^"
     my ($bd_tags) = $src =~ /\$self->\{escaped_tags\} \|\| '([^']+)'/;
     die "smoke denylist drifted from Board.pm escape_tags fallback\n"
         unless defined $bd_tags && $bd_tags eq $escaped_tags;
+    # exact match, not substring: a tightened scheme list or a changed
+    # replacement target must fail here (else this suite green-lights
+    # sanitization behavior production no longer has). $href_strip and
+    # the executable copy in render() below must stay byte-identical to
+    # this captured line.
     my ($bd_href) = $src =~ /(s\/\\shref[^\n]*\/gi;)/;
     die "smoke href strip drifted from Board.pm format_article\n"
-        unless defined $bd_href && index($bd_href, 'javascript|data|vbscript') >= 0;
+        unless defined $bd_href && $bd_href eq $href_strip;
 }
 
 sub render {
@@ -232,9 +237,10 @@ $body = render("> | a | b |\n> |---|---|\n> | 1 | 2 |\n| 3 | 4 |\n");
 
 # --- deep-review round 1 fixtures ---
 
-# fence info strings beyond \w: c++, c#, objective-c
+# fence info strings beyond \w: c++/c# map to prism grammar names,
+# hyphenated tags pass through
 $body = render(qq{```c++\nint x = v.size();\n```});
-&assert_contains('c++ fence class', $body, '<pre><code class="language-c++">int x = v.size();');
+&assert_contains('c++ fence class', $body, '<pre><code class="language-cpp">int x = v.size();');
 $body = render(qq{```objective-c\nid obj;\n```});
 &assert_contains('hyphenated fence class', $body, 'class="language-objective-c"');
 
@@ -298,5 +304,51 @@ $body = render("| a | b |\r\n|---|---|\r\n| 1 | 2 |\r\n");
 # loose task list (blank line between items -> <li><p>)
 $body = render("- [ ] 하나\n\n- [x] 둘\n");
 &assert_contains('loose task checkbox', $body, '<input type="checkbox" disabled');
+&assert_contains('loose task keeps p', $body, '<li style="list-style-type:none"><p><input');
+
+# --- deep-review round 2 fixtures ---
+
+# inline $..$ wrapping a display token must not nest (would leak \x1A)
+$body = render('함수 $f = \(x\)$ 로 둔다');
+&assert_not_contains('inline around display no sentinel leak', $body, "\x{1A}");
+&assert_not_contains('inline around display no M0M', $body, 'M0M');
+&assert_contains('inner display math survives', $body, '\(x\)');
+
+# ReDoS guard: a big body of unmatched \( (no closer) must render fast
+# and clean. The closer-existence guard skips the \( branch entirely
+# (O(1)); Text::Markdown then unescapes \( -> ( as ordinary markdown.
+# (Correctness only; timing is checked out-of-band. Without the guard
+# + length bound this is O(n^2) -- ~37s for a 64KB body.)
+$body = render('\(x ' x 4000);
+&assert_contains('unmatched openers unescaped', $body, '(x ');
+&assert_not_contains('unmatched openers no sentinel', $body, "\x{1A}");
+
+# display math with a real closer still shields
+$body = render('식은 \(a+b\) 이다');
+&assert_contains('paren display shielded', $body, '\(a+b\)');
+
+# same footnote cited twice: ref ids must be unique (valid HTML)
+$body = render("처음[^1] 그리고 다시[^1] 참조.\n\n[^1]: 정의\n");
+&assert_contains('fn first ref id', $body, 'id="fnref-77-1"');
+&assert_contains('fn repeat ref id suffixed', $body, 'id="fnref-77-1-2"');
+{
+    my $n = () = $body =~ /id="fnref-77-1"/g;
+    die "duplicate fnref id (got $n)\n" unless $n == 1;
+}
+
+# ~~x~~ inside a table cell code span stays literal (guarded like top level)
+$body = render("| a | b |\n|---|---|\n| `~~x~~` | 2 |\n");
+&assert_contains('cell code keeps tildes', $body, '<code>~~x~~</code>');
+&assert_not_contains('cell code no del', $body, '<del>x</del>');
+
+# ~~x~~ inside a footnote-def code span stays literal too
+$body = render("본문[^1] 참조.\n\n[^1]: 코드 `~~y~~` 유지\n");
+&assert_contains('fn def code keeps tildes', $body, '<code>~~y~~</code>');
+
+# c++ / c# fences map to prism's canonical grammar names
+$body = render(qq{```c++\nint x;\n```});
+&assert_contains('cpp alias class', $body, '<pre><code class="language-cpp">');
+$body = render(qq{```c#\nint x;\n```});
+&assert_contains('csharp alias class', $body, '<pre><code class="language-csharp">');
 
 print "ok\n";

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -179,4 +179,27 @@ $body = render('허공[^nope] 참조');
 $body = render(qq{```\n각주[^1] 문법\n```\n\n[^1]: 정의\n});
 &assert_contains('fn ref in fence literal', $body, '각주[^1] 문법');
 
+# --- blockquote nesting fixtures ---
+
+# fence inside a blockquote: quote prefix stripped from code, block stays
+# inside the quote
+$body = render(qq{> 인용 속 코드:\n>\n> ```python\n> def f(): pass\n> ```\n});
+&assert_contains('quoted fence class', $body, '<pre><code class="language-python">def f(): pass');
+die "quoted fence not inside blockquote:\n$body"
+    unless $body =~ m{<blockquote>.*<pre><code class="language-python">.*</blockquote>}s;
+
+# code lines keeping their own > chars beyond the quote level
+$body = render(qq{> ```\n> cmd >> out.txt\n> ```\n});
+&assert_contains('quoted fence redirect chars', $body, 'cmd &gt;&gt; out.txt');
+
+# table inside a blockquote
+$body = render("> | a | b |\n> |---|--:|\n> | 1 | 2 |\n");
+&assert_contains('quoted table right align', $body, '<td align="right">2</td>');
+die "quoted table not inside blockquote:\n$body"
+    unless $body =~ m{<blockquote>.*<table>.*</blockquote>}s;
+
+# a quoted table stops at a quote-level change
+$body = render("> | a | b |\n> |---|---|\n> | 1 | 2 |\n| 3 | 4 |\n");
+&assert_not_contains('level change ends table', $body, '<td>3</td>');
+
 print "ok\n";

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -332,10 +332,18 @@ $body = render('함수 $f = \(x\)$ 로 둔다');
         if time - $t0 > 2;
 }
 &assert_not_contains('mixed openers no sentinel', $body, "\x{1A}");
-# a large display formula (>2KB, past the old byte cap) shields intact
-$body = render('$$' . ('a & b & c & d \\\\ ' x 100) . '$$');
+# a large display formula (~4KB, well past round-2's removed 2000-byte
+# cap) shields intact -- pins the "no length cap" property
+$body = render('$$' . ('a & b & c & d \\\\ ' x 250) . '$$');
 &assert_contains('big formula shielded', $body, 'a & b & c & d \\\\ a');
 &assert_not_contains('big formula not em', $body, '<em>');
+
+# LaTeX row break \\[1ex] inside \[..\] must not be read as a nested \[
+# opener (else the span opener is corrupted and MathJax can't render)
+$body = render('\[ x_1 = 1 \\\\[1ex] y_2 = 2 \]');
+&assert_contains('rowbreak bracket intact', $body, '\[ x_1 = 1 \\\\[1ex] y_2 = 2 \]');
+$body = render('\( a \\\\[0.5em] b \)');
+&assert_contains('rowbreak paren intact', $body, '\( a \\\\[0.5em] b \)');
 
 # display math with a real closer still shields
 $body = render('식은 \(a+b\) 이다');
@@ -358,6 +366,11 @@ $body = render("| a | b |\n|---|---|\n| `~~x~~` | 2 |\n");
 # ~~x~~ inside a footnote-def code span stays literal too
 $body = render("본문[^1] 참조.\n\n[^1]: 코드 `~~y~~` 유지\n");
 &assert_contains('fn def code keeps tildes', $body, '<code>~~y~~</code>');
+
+# raw <pre> with a nested <code>: ~~ after the inner </code> but still
+# inside <pre> must stay literal (region captured as one unit)
+$body = render('<pre>~~a~~ <code>b</code> ~~c~~</pre>');
+&assert_not_contains('pre-nested-code no del', $body, '<del>');
 
 # c++ / c# fences map to prism's canonical grammar names
 $body = render(qq{```c++\nint x;\n```});

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -3,6 +3,7 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/../../lib";
 use Bawi::Markdown;
+use Time::HiRes qw(time);
 
 # The denylist below mirrors escape_tags' CODE FALLBACK. Production
 # reads the per-board bw_xboard_board.escaped_tags column, whose schema
@@ -20,13 +21,16 @@ my $href_strip   = 's/\shref\s*=\s*(["\'])\s*(?:javascript|data|vbscript)\s*:[^"
         unless defined $bd_tags && $bd_tags eq $escaped_tags;
     # exact match, not substring: a tightened scheme list or a changed
     # replacement target must fail here (else this suite green-lights
-    # sanitization behavior production no longer has). $href_strip and
-    # the executable copy in render() below must stay byte-identical to
-    # this captured line.
+    # sanitization behavior production no longer has).
     my ($bd_href) = $src =~ /(s\/\\shref[^\n]*\/gi;)/;
     die "smoke href strip drifted from Board.pm format_article\n"
         unless defined $bd_href && $bd_href eq $href_strip;
 }
+
+# Single source of truth: compile the drift-checked $href_strip once and
+# run THAT in render(), so there is no third hand-maintained copy to drift.
+my $apply_href = eval "sub { local \$_ = shift; $href_strip return \$_; }"
+    or die "cannot compile href strip: $@";
 
 sub render {
     # 77 stands in for the article id Board.pm passes (footnote anchors
@@ -37,7 +41,7 @@ sub render {
     # applies after Bawi::Markdown::render().
     my $tags = '(' . join("|", split(/\s+/, $escaped_tags) ) . ')';
     $body =~ s/<(\/?$tags)/&lt;$1/igox;
-    $body =~ s/\shref\s*=\s*(["'])\s*(?:javascript|data|vbscript)\s*:[^"']*\1/ href="#"/gi;
+    $body = $apply_href->($body);
     return $body;
 }
 
@@ -314,14 +318,24 @@ $body = render('함수 $f = \(x\)$ 로 둔다');
 &assert_not_contains('inline around display no M0M', $body, 'M0M');
 &assert_contains('inner display math survives', $body, '\(x\)');
 
-# ReDoS guard: a big body of unmatched \( (no closer) must render fast
-# and clean. The closer-existence guard skips the \( branch entirely
-# (O(1)); Text::Markdown then unescapes \( -> ( as ordinary markdown.
-# (Correctness only; timing is checked out-of-band. Without the guard
-# + length bound this is O(n^2) -- ~37s for a 64KB body.)
-$body = render('\(x ' x 4000);
-&assert_contains('unmatched openers unescaped', $body, '(x ');
-&assert_not_contains('unmatched openers no sentinel', $body, "\x{1A}");
+# ReDoS guard: opener-exclusion makes a dangling \( / \[ fail at the
+# NEXT opener, so a body of unmatched openers is O(n), not O(n^2). This
+# must hold even when a SECOND delimiter family is present (which keeps
+# all alternation branches live). Wall-clock guard: the pre-fix code
+# took seconds on this input; healthy is well under a second.
+{
+    # coarse regression tripwire (healthy ~0.15s; pre-fix O(n^2) ~2.7s
+    # on this 64KB input). Generous 2s bound tolerates load spikes.
+    my $t0 = time;
+    $body = render(('\(x ' x 16000) . '\)\]');   # 64KB, two branches live
+    die sprintf("math ReDoS regression: render took %.2fs (expected <2)\n", time - $t0)
+        if time - $t0 > 2;
+}
+&assert_not_contains('mixed openers no sentinel', $body, "\x{1A}");
+# a large display formula (>2KB, past the old byte cap) shields intact
+$body = render('$$' . ('a & b & c & d \\\\ ' x 100) . '$$');
+&assert_contains('big formula shielded', $body, 'a & b & c & d \\\\ a');
+&assert_not_contains('big formula not em', $body, '<em>');
 
 # display math with a real closer still shields
 $body = render('식은 \(a+b\) 이다');

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -150,4 +150,33 @@ $body = render('code `~~x~~` keeps tildes');
 $body = render("    ~~x~~ indented code");
 &assert_not_contains('no del in code block', $body, '<del>');
 
+# --- task list fixtures ---
+
+$body = render("- [ ] 할 일\n- [x] 끝난 일\n");
+&assert_contains('task unchecked', $body, '<input type="checkbox" disabled> 할 일');
+&assert_contains('task checked', $body, '<input type="checkbox" disabled checked> 끝난 일');
+&assert_contains('task bullet suppressed', $body, '<li style="list-style-type:none">');
+
+$body = render('[ ] 목록 아님');
+&assert_not_contains('bracket outside list not task', $body, '<input');
+
+# --- footnote fixtures ---
+
+$body = render("본문[^1] 이고 다시[^note] 참조.\n\n[^1]: 첫 각주 **강조**\n[^note]: 둘째 \$E=mc^2\$ 각주\n");
+&assert_contains('fn ref sup', $body, '<sup id="fnref-1"><a href="#fn-1">1</a></sup>');
+&assert_contains('fn ref second number', $body, '<a href="#fn-note">2</a>');
+&assert_contains('fn list item', $body, '<li id="fn-1">첫 각주 <strong>강조</strong>');
+&assert_contains('fn backlink', $body, '<a href="#fnref-1">&#8617;</a>');
+&assert_contains('fn math in def', $body, '\(E=mc^2\)');
+&assert_not_contains('fn def line removed', $body, '[^1]:');
+
+# unknown reference stays literal; no footnote section without defs
+$body = render('허공[^nope] 참조');
+&assert_contains('unknown fn ref literal', $body, '[^nope]');
+&assert_not_contains('no fn section', $body, 'class="footnotes"');
+
+# fn ref inside a fence stays literal
+$body = render(qq{```\n각주[^1] 문법\n```\n\n[^1]: 정의\n});
+&assert_contains('fn ref in fence literal', $body, '각주[^1] 문법');
+
 print "ok\n";

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -4,13 +4,33 @@ use FindBin;
 use lib "$FindBin::Bin/../../lib";
 use Bawi::Markdown;
 
+# The denylist below mirrors escape_tags' CODE FALLBACK. Production
+# reads the per-board bw_xboard_board.escaped_tags column, whose schema
+# default omits "head style link" -- so keep sanitization assertions to
+# tags present in BOTH lists (script, iframe). The drift check below
+# fails this suite if Board.pm's fallback list or href strip changes.
+my $escaped_tags = 'html body embed iframe applet script bgsound object meta head style link';
+my $href_strip   = 's/\shref\s*=\s*(["\'])\s*(?:javascript|data|vbscript)\s*:[^"\']*\1/ href="#"/gi;';
+
+{
+    open my $fh, '<', "$FindBin::Bin/../../lib/Bawi/Board.pm" or die "Board.pm: $!";
+    local $/; my $src = <$fh>;
+    my ($bd_tags) = $src =~ /\$self->\{escaped_tags\} \|\| '([^']+)'/;
+    die "smoke denylist drifted from Board.pm escape_tags fallback\n"
+        unless defined $bd_tags && $bd_tags eq $escaped_tags;
+    my ($bd_href) = $src =~ /(s\/\\shref[^\n]*\/gi;)/;
+    die "smoke href strip drifted from Board.pm format_article\n"
+        unless defined $bd_href && index($bd_href, 'javascript|data|vbscript') >= 0;
+}
+
 sub render {
-    my $body = Bawi::Markdown::render(shift);
+    # 77 stands in for the article id Board.pm passes (footnote anchors
+    # come out as fn-77-N)
+    my $body = Bawi::Markdown::render(shift, 77);
 
     # escape_tags denylist + href strip, as Bawi::Board::format_article
     # applies after Bawi::Markdown::render().
-    my $escaped_tags = 'html body embed iframe applet script bgsound object meta head style link';
-    my $tags = '(' . join("|", split(/\s+/, $escaped_tags) ) . ')'; 
+    my $tags = '(' . join("|", split(/\s+/, $escaped_tags) ) . ')';
     $body =~ s/<(\/?$tags)/&lt;$1/igox;
     $body =~ s/\shref\s*=\s*(["'])\s*(?:javascript|data|vbscript)\s*:[^"']*\1/ href="#"/gi;
     return $body;
@@ -163,12 +183,20 @@ $body = render('[ ] 목록 아님');
 # --- footnote fixtures ---
 
 $body = render("본문[^1] 이고 다시[^note] 참조.\n\n[^1]: 첫 각주 **강조**\n[^note]: 둘째 \$E=mc^2\$ 각주\n");
-&assert_contains('fn ref sup', $body, '<sup id="fnref-1"><a href="#fn-1">1</a></sup>');
-&assert_contains('fn ref second number', $body, '<a href="#fn-note">2</a>');
-&assert_contains('fn list item', $body, '<li id="fn-1">첫 각주 <strong>강조</strong>');
-&assert_contains('fn backlink', $body, '<a href="#fnref-1">&#8617;</a>');
+&assert_contains('fn ref sup', $body, '<sup id="fnref-77-1"><a href="#fn-77-1">1</a></sup>');
+&assert_contains('fn ref second number', $body, '<a href="#fn-77-2">2</a>');
+&assert_contains('fn list item', $body, '<li id="fn-77-1">첫 각주 <strong>강조</strong>');
+&assert_contains('fn backlink', $body, '<a href="#fnref-77-1">&#8617;</a>');
 &assert_contains('fn math in def', $body, '\(E=mc^2\)');
 &assert_not_contains('fn def line removed', $body, '[^1]:');
+
+# Korean footnote labels: anchors key on the NUMBER (byte-mode \w
+# would strip hangul labels to "", colliding every anchor)
+$body = render("트위스터[^주석] 그리고 구글리[^참고] 문제.\n\n[^주석]: 첫째\n[^참고]: 둘째\n");
+&assert_contains('korean fn first anchor', $body, '<sup id="fnref-77-1"><a href="#fn-77-1">1</a></sup>');
+&assert_contains('korean fn second anchor', $body, '<sup id="fnref-77-2"><a href="#fn-77-2">2</a></sup>');
+&assert_contains('korean fn list items', $body, '<li id="fn-77-2">둘째');
+&assert_not_contains('korean fn no empty anchor', $body, 'id="fn-77-"');
 
 # unknown reference stays literal; no footnote section without defs
 $body = render('허공[^nope] 참조');
@@ -201,5 +229,74 @@ die "quoted table not inside blockquote:\n$body"
 # a quoted table stops at a quote-level change
 $body = render("> | a | b |\n> |---|---|\n> | 1 | 2 |\n| 3 | 4 |\n");
 &assert_not_contains('level change ends table', $body, '<td>3</td>');
+
+# --- deep-review round 1 fixtures ---
+
+# fence info strings beyond \w: c++, c#, objective-c
+$body = render(qq{```c++\nint x = v.size();\n```});
+&assert_contains('c++ fence class', $body, '<pre><code class="language-c++">int x = v.size();');
+$body = render(qq{```objective-c\nid obj;\n```});
+&assert_contains('hyphenated fence class', $body, 'class="language-objective-c"');
+
+# fences are no longer <p>-wrapped (tables already were not)
+$body = render(qq{```\nplain\n```});
+&assert_not_contains('fence not p-wrapped', $body, '<p><pre');
+$body = render(qq{> ```\n> quoted\n> ```});
+&assert_not_contains('quoted fence not p-wrapped', $body, '<p><pre');
+
+# an unbalanced $$ stays literal: the fence after it survives and
+# blocks in between keep their structure
+$body = render(qq{비용은 \$\$ 큽니다.\n\n## 소제목\n\n```perl\nmy \$x;\n```\n});
+&assert_contains('unbalanced dollars keep heading', $body, '<h2>소제목</h2>');
+&assert_contains('unbalanced dollars keep fence', $body, '<pre><code class="language-perl">');
+&assert_not_contains('no leaked sentinel bytes', $body, "\x{1A}");
+
+# display math still crosses plain line breaks (one paragraph)...
+$body = render("\$\$\na + b = c\n\$\$");
+&assert_contains('multiline display math', $body, "\$\$\na + b = c\n\$\$");
+# ...but never a blank line
+$body = render("\$\$ 시작\n\n끝 \$\$ 그리고 \$\$x\$\$");
+&assert_not_contains('display math stops at blank line', $body, '시작' . "\n\n" . '끝');
+
+# postfix currency: digit before the opening $ blocks inline math
+$body = render('이건 5$짜리와 10$짜리 입니다.');
+&assert_not_contains('postfix currency not math', $body, '\(');
+
+# one $..$ cannot merge two inline code spans (content excludes `)
+$body = render('변수 `$total` 과 `$price` 비교');
+&assert_contains('code spans intact', $body, '<code>$total</code>');
+&assert_not_contains('code spans not merged', $body, '\(total');
+
+# \$ is a literal dollar (pandoc parity)
+$body = render('세금은 \$100 정도입니다.');
+&assert_contains('escaped dollar literal', $body, '세금은 $100 정도입니다.');
+
+# user-typed sentinel bytes are stripped, not honored as tokens
+$body = render("위조 \x{1A}M0M\x{1A} 토큰과 \$x\$ 수식");
+&assert_contains('forged token neutralized', $body, '위조 M0M 토큰과');
+&assert_contains('real math still works', $body, '\(x\)');
+
+# javascript: URLs DISPLAYED inside a fence stay verbatim (quotes are
+# entity-escaped, so the href strip cannot rewrite them)
+$body = render(qq{```html\n<a href="javascript:alert(1)">x</a>\n```});
+&assert_contains('js url in fence displayed', $body, 'href=&quot;javascript:alert(1)&quot;');
+&assert_not_contains('js url in fence not stripped', $body, 'href="#"');
+
+# deep quote prefixes are capped, not fatal ({0,$lvl} would die past
+# 65534). Text::Markdown itself warns about deep blockquote recursion
+# on such input (pre-existing) -- silence that, we only assert no die.
+{
+    local $SIG{__WARN__} = sub {};
+    $body = render((">" x 150) . " ```\n" . (">" x 150) . " deep\n" . (">" x 150) . " ```");
+}
+&assert_contains('deep quote fence renders', $body, '<pre><code>');
+
+# CRLF input end-to-end
+$body = render("| a | b |\r\n|---|---|\r\n| 1 | 2 |\r\n");
+&assert_contains('crlf table', $body, '<td>1</td>');
+
+# loose task list (blank line between items -> <li><p>)
+$body = render("- [ ] 하나\n\n- [x] 둘\n");
+&assert_contains('loose task checkbox', $body, '<input type="checkbox" disabled');
 
 print "ok\n";

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -2,19 +2,13 @@
 use strict;
 use FindBin;
 use lib "$FindBin::Bin/../../lib";
-use Text::Markdown;
+use Bawi::Markdown;
 
 sub render {
-    my $body = shift;
+    my $body = Bawi::Markdown::render(shift);
 
-    # Same markdown pipeline as Bawi::Board::format_article.
-    my @math;
-    my $shield = sub { push @math, $_[0]; "\x{1A}M" . $#math . "M\x{1A}" };
-    $body =~ s/(\$\$.+?\$\$|\\\[.+?\\\]|\\\(.+?\\\))/$shield->($1)/egs;
-    $body =~ s/(?<![\$\\])\$(?=\S)([^\$\n]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
-    $body = Text::Markdown::markdown($body);
-    $body =~ s/\x{1A}M(\d+)M\x{1A}/$math[$1]/g;
-
+    # escape_tags denylist + href strip, as Bawi::Board::format_article
+    # applies after Bawi::Markdown::render().
     my $escaped_tags = 'html body embed iframe applet script bgsound object meta head style link';
     my $tags = '(' . join("|", split(/\s+/, $escaped_tags) ) . ')'; 
     $body =~ s/<(\/?$tags)/&lt;$1/igox;
@@ -105,5 +99,55 @@ $body = render("    \$\$x\$\$");
 $body = render('$$<script>alert(1)</script>$$');
 &assert_contains('script in math escaped', $body, '&lt;script');
 &assert_not_contains('script in math escaped', $body, '<script');
+
+# --- fenced code block fixtures ---
+
+# ```lang fence -> <pre><code class="language-..."> with entities escaped,
+# and $ inside code never becomes math
+$body = render(qq{```perl\nmy \$x = <STDIN>;\nprint "\$x & \$y";\n```});
+&assert_contains('fence language class', $body, '<pre><code class="language-perl">');
+&assert_contains('fence escapes angle', $body, 'my $x = &lt;STDIN&gt;;');
+&assert_contains('fence escapes amp', $body, '&amp;');
+&assert_not_contains('fence dollar not math', $body, '\(');
+
+# bare fence -> plain <pre><code>
+$body = render(qq{```\nplain block\n```});
+&assert_contains('bare fence', $body, '<pre><code>plain block');
+
+# $$ inside a fence stays literal (MathJax skips <code>)
+$body = render(qq{```\n\$\$x\$\$\n```});
+&assert_contains('math in fence literal', $body, '$$x$$');
+
+# markdown markup inside a fence stays literal
+$body = render(qq{```\n# not a heading\n```});
+&assert_not_contains('heading in fence literal', $body, '<h1>');
+
+# --- pipe table fixtures ---
+
+my $table = "| 변수 | 의미 | 노름 |\n|:-----|:----:|-----:|\n| \$Z\$ | **정칙** | 1 |\n";
+$body = render($table);
+&assert_contains('table built', $body, '<table><thead><tr><th align="left">변수</th>');
+&assert_contains('table center align', $body, '<th align="center">의미</th>');
+&assert_contains('table right align', $body, '<td align="right">1</td>');
+&assert_contains('table cell strong', $body, '<td align="center"><strong>정칙</strong></td>');
+&assert_contains('table cell math', $body, '<td align="left">\(Z\)</td>');
+&assert_not_contains('table not p-wrapped', $body, '<p><table');
+
+# escaped pipe in a cell; prose with pipes but no separator is not a table
+$body = render("| a\\|b | c |\n|---|---|\n| 1 | 2 |\n");
+&assert_contains('escaped pipe in cell', $body, '<th>a|b</th>');
+$body = render("this | that\nother | thing\n");
+&assert_not_contains('prose pipes not table', $body, '<table');
+
+# --- strikethrough fixtures ---
+
+$body = render('~~틀린 내용~~ 이렇게 지웁니다.');
+&assert_contains('strikethrough', $body, '<del>틀린 내용</del>');
+
+$body = render('code `~~x~~` keeps tildes');
+&assert_not_contains('no del in code span', $body, '<del>');
+
+$body = render("    ~~x~~ indented code");
+&assert_not_contains('no del in code block', $body, '<del>');
 
 print "ok\n";

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -6,9 +6,15 @@ use Text::Markdown;
 
 sub render {
     my $body = shift;
-    $body = Text::Markdown::markdown($body);
 
     # Same markdown pipeline as Bawi::Board::format_article.
+    my @math;
+    my $shield = sub { push @math, $_[0]; "\x{1A}M" . $#math . "M\x{1A}" };
+    $body =~ s/(\$\$.+?\$\$|\\\[.+?\\\]|\\\(.+?\\\))/$shield->($1)/egs;
+    $body =~ s/(?<![\$\\])\$(?=\S)([^\$\n]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
+    $body = Text::Markdown::markdown($body);
+    $body =~ s/\x{1A}M(\d+)M\x{1A}/$math[$1]/g;
+
     my $escaped_tags = 'html body embed iframe applet script bgsound object meta head style link';
     my $tags = '(' . join("|", split(/\s+/, $escaped_tags) ) . ')'; 
     $body =~ s/<(\/?$tags)/&lt;$1/igox;
@@ -54,5 +60,50 @@ $body = render("> quoted");
 
 $body = render("<b>hi</b>");
 &assert_contains('plain b tag', $body, '<b>hi</b>');
+
+# --- MathJax shield fixtures ---
+
+# bare TeX in prose stays literal (no delimiters, no MathJax -- unchanged)
+$body = render('반정칙 변수인 \bar{Z}를 사용한다.');
+&assert_contains('bare tex literal', $body, '\bar{Z}');
+
+# inline $..$ emitted as \(..\) (site MathJax config processes \(..\) inline)
+$body = render('변수인 $\bar{Z}$를 사용한다.');
+&assert_contains('inline dollar to paren', $body, '\(\bar{Z}\)');
+&assert_not_contains('inline dollar consumed', $body, '$');
+
+# $$..$$ survives verbatim: no <em> from _ subscripts after braces
+$body = render('$$\bar{Z}_\alpha \bar{W}_\beta$$');
+&assert_contains('display underscores intact', $body, '$$\bar{Z}_\alpha \bar{W}_\beta$$');
+&assert_not_contains('display underscores intact', $body, '<em>');
+
+# \[..\] and \(..\) no longer eaten by backslash-escape processing
+$body = render('\[ Z_\alpha \bar{Z}^\alpha = 0 \]');
+&assert_contains('bracket display intact', $body, '\[ Z_\alpha \bar{Z}^\alpha = 0 \]');
+$body = render('여기서 \(\bar{Z}\) 는 반정칙 변수다.');
+&assert_contains('paren inline intact', $body, '\(\bar{Z}\)');
+
+# \\ row separators survive inside display math
+$body = render('$$\begin{pmatrix} a \\\\ b \end{pmatrix}$$');
+&assert_contains('matrix row sep intact', $body, 'a \\\\ b');
+
+# currency stays currency (pandoc closing rules)
+$body = render('커피는 $5 이고 케이크는 $10 이다.');
+&assert_not_contains('currency not math', $body, '\(');
+
+# markdown still works around shielded math
+$body = render('**중요** $x_i$ 입니다');
+&assert_contains('bold beside math', $body, '<strong>');
+&assert_contains('bold beside math', $body, '\(x_i\)');
+
+# $$ inside an indented code block round-trips literally (MathJax skips <code>)
+$body = render("    \$\$x\$\$");
+&assert_contains('math in code literal', $body, '<pre><code>');
+&assert_contains('math in code literal', $body, '$$x$$');
+
+# escape_tags denylist still applies to shielded math content
+$body = render('$$<script>alert(1)</script>$$');
+&assert_contains('script in math escaped', $body, '&lt;script');
+&assert_not_contains('script in math escaped', $body, '<script');
 
 print "ok\n";

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -355,6 +355,10 @@ $body = render("\\[ x \\\\\n\n# 제목\n\n\\]");
 # bare-CR (classic-Mac) blank line must block too, not just LF/CRLF
 $body = render("\\[ x \\\\\r\r# 제목\r\r\\]");
 &assert_contains('bare-CR blank line not crossed', $body, '<h1>제목</h1>');
+# a SINGLE CRLF soft break inside a display span must still CROSS (shield)
+# -- browsers POST CRLF, so this is the normal multi-line-formula path
+$body = render("\\[\r\na + b\r\n\\]");
+&assert_contains('single CRLF soft break shields', $body, "\\[\r\na + b\r\n\\]");
 
 # display math with a real closer still shields
 $body = render('식은 \(a+b\) 이다');

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -342,8 +342,16 @@ $body = render('$$' . ('a & b & c & d \\\\ ' x 250) . '$$');
 # opener (else the span opener is corrupted and MathJax can't render)
 $body = render('\[ x_1 = 1 \\\\[1ex] y_2 = 2 \]');
 &assert_contains('rowbreak bracket intact', $body, '\[ x_1 = 1 \\\\[1ex] y_2 = 2 \]');
-$body = render('\( a \\\\[0.5em] b \)');
-&assert_contains('rowbreak paren intact', $body, '\( a \\\\[0.5em] b \)');
+# an ESCAPED open-paren \\( inside \(..\) must survive (pins the paren
+# branch's escaped-pair -- a \\[ here would not, it never trips (?!\\\())
+$body = render('\( a \\\\(x b \)');
+&assert_contains('rowbreak paren intact', $body, '\( a \\\\(x b \)');
+# a \\ row break right before a BLANK line must NOT let the span cross
+# it (else a following heading is swallowed into shielded math source).
+# Pre-fix the escaped pair ate the first newline and the span reached
+# the trailing \] , swallowing the heading.
+$body = render("\\[ x \\\\\n\n# 제목\n\n\\]");
+&assert_contains('blank line not crossed by escaped pair', $body, '<h1>제목</h1>');
 
 # display math with a real closer still shields
 $body = render('식은 \(a+b\) 이다');

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -292,14 +292,21 @@ $body = render(qq{```html\n<a href="javascript:alert(1)">x</a>\n```});
 &assert_contains('js url in fence displayed', $body, 'href=&quot;javascript:alert(1)&quot;');
 &assert_not_contains('js url in fence not stripped', $body, 'href="#"');
 
-# deep quote prefixes are capped, not fatal ({0,$lvl} would die past
-# 65534). Text::Markdown itself warns about deep blockquote recursion
-# on such input (pre-existing) -- silence that, we only assert no die.
+# deep quote nesting is clamped to 32 levels: renders fast (no super-
+# linear Text::Markdown recursion) and emits at most 32 nested
+# blockquotes, not 150. Also a fence still renders inside the (clamped)
+# quote. Timing tripwire: pre-cap this hung for seconds.
 {
-    local $SIG{__WARN__} = sub {};
+    my $t0 = time;
     $body = render((">" x 150) . " ```\n" . (">" x 150) . " deep\n" . (">" x 150) . " ```");
+    die sprintf("deep-quote perf regression: %.2fs (expected <1)\n", time - $t0)
+        if time - $t0 > 1;
 }
 &assert_contains('deep quote fence renders', $body, '<pre><code>');
+{
+    my $n = () = $body =~ /<blockquote>/g;
+    die "quote depth not clamped (got $n nested blockquotes)\n" if $n > 32;
+}
 
 # CRLF input end-to-end
 $body = render("| a | b |\r\n|---|---|\r\n| 1 | 2 |\r\n");

--- a/board/script/markdown_smoke.pl
+++ b/board/script/markdown_smoke.pl
@@ -352,6 +352,9 @@ $body = render('\( a \\\\(x b \)');
 # the trailing \] , swallowing the heading.
 $body = render("\\[ x \\\\\n\n# 제목\n\n\\]");
 &assert_contains('blank line not crossed by escaped pair', $body, '<h1>제목</h1>');
+# bare-CR (classic-Mac) blank line must block too, not just LF/CRLF
+$body = render("\\[ x \\\\\r\r# 제목\r\r\\]");
+&assert_contains('bare-CR blank line not crossed', $body, '<h1>제목</h1>');
 
 # display math with a real closer still shields
 $body = render('식은 \(a+b\) 이다');

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -1146,13 +1146,16 @@ sub format_article {
     # unquoted hrefs bypass it). Do NOT reuse this path for untrusted input
     # (comments, anonymous/public boards) without a real allowlist sanitizer.
     if ($article && $$article{category} && $$article{category} == 1) {
-        # Bawi::Markdown = Text::Markdown + MathJax span shielding + ```
-        # fences (prism) + GFM pipe tables + ~~strikethrough~~. It does NO
-        # sanitizing of its own: escape_tags below applies the same tag
-        # denylist to its output (math/fence/table content included).
+        # Bawi::Markdown renders the body (see that module's header for
+        # the full pipeline). It does NO sanitizing of its own:
+        # escape_tags below applies the same tag denylist to its output
+        # (math/fence/table content included). The article id namespaces
+        # footnote anchors so thread/new-articles pages that render many
+        # articles don't emit duplicate ids.
         require Bawi::Markdown;
-        $body = Bawi::Markdown::render($body);
+        $body = Bawi::Markdown::render($body, $$article{article_id} || '');
         $body = &escape_tags($self, $body);
+        # keep in sync with board/script/markdown_smoke.pl (drift-checked there)
         $body =~ s/\shref\s*=\s*(["'])\s*(?:javascript|data|vbscript)\s*:[^"']*\1/ href="#"/gi;
         return $body;
     }
@@ -2723,6 +2726,9 @@ sub traverse {
 sub escape_tags {
     my $self = shift;
     $_ = shift;
+    # per-board bw_xboard_board.escaped_tags (schema default omits
+    # head/style/link); the fallback below is drift-checked by
+    # board/script/markdown_smoke.pl -- keep them in sync
     my $escaped_tags = $self->{escaped_tags} || 'html body embed iframe applet script bgsound object meta head style link';
     my $tags = '(' . join("|", split(/\s+/, $escaped_tags) ) . ')'; 
     $_ =~ s/<(\/?$tags)/&lt;$1/igox;

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -1146,25 +1146,12 @@ sub format_article {
     # unquoted hrefs bypass it). Do NOT reuse this path for untrusted input
     # (comments, anonymous/public boards) without a real allowlist sanitizer.
     if ($article && $$article{category} && $$article{category} == 1) {
-        require Text::Markdown;
-        # Shield MathJax spans from the Markdown parser: backslash-escape
-        # processing eats \( \) \[ \] \\ \{ \}, and emphasis can inject <em>
-        # into $$..$$ (e.g. an _ subscript right after a closing brace).
-        # Spans are restored verbatim BEFORE escape_tags so math text still
-        # passes the same denylist as everything else. Inline $..$ (pandoc
-        # rule: non-space inside, closing $ not followed by a digit, single
-        # line -- keeps "$5 ... $10" as currency) is emitted as \(..\): the
-        # loaded MathJax config (TeX-MML-AM_CHTML) has single-$ off but
-        # already processes \(..\) inline, so no client config change.
-        # ponytail: blind to code blocks -- $$ inside a code block round-trips
-        # literally and MathJax skips <code>, which is what showing TeX
-        # source wants anyway.
-        my @math;
-        my $shield = sub { push @math, $_[0]; "\x{1A}M" . $#math . "M\x{1A}" };
-        $body =~ s/(\$\$.+?\$\$|\\\[.+?\\\]|\\\(.+?\\\))/$shield->($1)/egs;
-        $body =~ s/(?<![\$\\])\$(?=\S)([^\$\n]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
-        $body = Text::Markdown::markdown($body);
-        $body =~ s/\x{1A}M(\d+)M\x{1A}/$math[$1]/g;
+        # Bawi::Markdown = Text::Markdown + MathJax span shielding + ```
+        # fences (prism) + GFM pipe tables + ~~strikethrough~~. It does NO
+        # sanitizing of its own: escape_tags below applies the same tag
+        # denylist to its output (math/fence/table content included).
+        require Bawi::Markdown;
+        $body = Bawi::Markdown::render($body);
         $body = &escape_tags($self, $body);
         $body =~ s/\shref\s*=\s*(["'])\s*(?:javascript|data|vbscript)\s*:[^"']*\1/ href="#"/gi;
         return $body;

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -1147,7 +1147,24 @@ sub format_article {
     # (comments, anonymous/public boards) without a real allowlist sanitizer.
     if ($article && $$article{category} && $$article{category} == 1) {
         require Text::Markdown;
+        # Shield MathJax spans from the Markdown parser: backslash-escape
+        # processing eats \( \) \[ \] \\ \{ \}, and emphasis can inject <em>
+        # into $$..$$ (e.g. an _ subscript right after a closing brace).
+        # Spans are restored verbatim BEFORE escape_tags so math text still
+        # passes the same denylist as everything else. Inline $..$ (pandoc
+        # rule: non-space inside, closing $ not followed by a digit, single
+        # line -- keeps "$5 ... $10" as currency) is emitted as \(..\): the
+        # loaded MathJax config (TeX-MML-AM_CHTML) has single-$ off but
+        # already processes \(..\) inline, so no client config change.
+        # ponytail: blind to code blocks -- $$ inside a code block round-trips
+        # literally and MathJax skips <code>, which is what showing TeX
+        # source wants anyway.
+        my @math;
+        my $shield = sub { push @math, $_[0]; "\x{1A}M" . $#math . "M\x{1A}" };
+        $body =~ s/(\$\$.+?\$\$|\\\[.+?\\\]|\\\(.+?\\\))/$shield->($1)/egs;
+        $body =~ s/(?<![\$\\])\$(?=\S)([^\$\n]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
         $body = Text::Markdown::markdown($body);
+        $body =~ s/\x{1A}M(\d+)M\x{1A}/$math[$1]/g;
         $body = &escape_tags($self, $body);
         $body =~ s/\shref\s*=\s*(["'])\s*(?:javascript|data|vbscript)\s*:[^"']*\1/ href="#"/gi;
         return $body;

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -2,64 +2,115 @@ package Bawi::Markdown;
 # Markdown rendering pipeline for category==1 articles: classic
 # Text::Markdown plus the extensions the board wants on top of it.
 #
-#   render($body) does, in order:
+#   render($body [, $uniq]) does, in order:
 #     1. ``` fenced code blocks -> <pre><code class="language-X">
-#        (classic Markdown only knows 4-space indentation; fences are
-#        extracted first so nothing inside code is ever taken for math,
-#        a table, or markup; prism.js in the skin does the highlighting)
-#     2. MathJax spans ($$..$$ \[..\] \(..\) and inline $..$) shielded
-#        from the parser; inline $..$ is emitted as \(..\) because the
-#        site MathJax config (TeX-MML-AM_CHTML) has single-$ off but
-#        already processes \(..\) -- no client config change
+#        (top level or inside blockquotes; extracted FIRST so nothing
+#        inside code is ever taken for math, a table, or markup;
+#        prism.js in the skin does the highlighting)
+#     2. MathJax spans shielded from the parser: $$..$$ \[..\] \(..\)
+#        verbatim, inline $..$ emitted as \(..\) (the site MathJax
+#        config, TeX-MML-AM_CHTML, has single-$ off but processes
+#        \(..\)); then \$ unescapes to a literal $
 #     3. footnotes: [^id] references + top-level "[^id]: text"
-#        definitions -> numbered <sup> links and a trailing footnote list
+#        definitions -> numbered <sup> links and a trailing footnote
+#        list appended after stage 8 (anchors are per-article numbers:
+#        fn-<uniq>-<n>, see $uniq below)
 #     4. GFM pipe tables -> <table> (Text::Markdown passes block-level
 #        HTML through untouched; cell contents get span-level markdown)
 #     5. Text::Markdown::markdown()
-#     6. ~~strikethrough~~ -> <del>, skipping <pre>/<code> regions
-#     7. task lists: <li>[ ] / <li>[x] -> disabled checkboxes
-#     8. shielded spans restored verbatim
+#     6. fence tokens unwrapped from the <p> the parser puts around
+#        bare-text lines (a <pre> may not sit inside <p>)
+#     7. ~~strikethrough~~ -> <del>, skipping <pre>/<code> regions
+#     8. task lists: <li>[ ] / <li>[x] -> disabled checkboxes
+#     9. shielded spans restored verbatim
+#
+#   $uniq: pass the article id. It namespaces footnote anchors
+#   (fn-<uniq>-<n>) so several rendered articles can share one page
+#   (thread view, new-articles view) without duplicate ids.
 #
 #   Sanitization (escape_tags denylist, href scheme strip) is NOT done
 #   here -- Bawi::Board::format_article applies it after render(), so
-#   math/fence/table content passes the same denylist as everything else.
+#   math/fence/table content passes the same denylist as everything
+#   else. NOTE for future MathJax upgrades: the client config must NOT
+#   enable the HTML.js extension (\href, \style) -- that would make
+#   $$..$$ content a client-side link sink the server-side href strip
+#   never sees.
 #
-# ponytail ceilings (v1): fences/tables work at top level and inside
-# blockquotes, but NOT inside list items -- that would need real block-
-# structure parsing (4-space indent inside a list item already means
-# "code block" in classic markdown); 8-space-indented code inside a list
-# item is native and works. Footnote definitions are top-level and
-# single-line. A pipe-table lookalike inside 4-space indented code is
-# parsed as a table (use a ``` fence for code instead); escape a literal
-# | in a table cell as \|; a single $..$ can eat a | if one math span is
-# written across two cells; $..$ and [^ref] inside inline `code spans`
-# and 4-space blocks are still transformed (fences are fully immune).
+# Known limitations (deliberate v1 scope cuts):
+#   - fences/tables work at top level and inside blockquotes, but NOT
+#     inside list items: a structure-blind pre-pass cannot tell a
+#     4-space-indented fence inside a list item from 4-space-indented
+#     code at top level (that needs real block parsing). 8-space-
+#     indented code inside a list item is native classic markdown and
+#     works.
+#   - footnote definitions are top-level and single-line
+#   - a pipe-table lookalike inside 4-space-indented code is parsed as
+#     a table (use a ``` fence for code instead)
+#   - escape a literal | in a table cell as \|
+#   - table cells and footnote definitions are span-level context:
+#     reference-style links do not resolve there, and block syntax in
+#     a cell degrades
+#   - $..$ / [^ref] sitting entirely inside ONE inline `code span` or
+#     a 4-space indented block are still transformed (``` fences are
+#     fully immune; an inline $..$ can no longer MERGE two code spans,
+#     since its content excludes backticks)
+#   - a fence's closing ``` may sit at any quote level (lazy
+#     continuation); the opening line's prefix decides the strip level
+#   - ~~..~~ inside a tag attribute (a URL containing two ~~ runs) is
+#     still rewritten
+
 use strict;
 use warnings;
 use Text::Markdown;
 
 sub render {
-    my $body = shift;
+    my ($body, $uniq) = @_;
     return $body unless defined $body;
+    $uniq = defined $uniq && length $uniq ? "$uniq-" : '';
+
+    # \x1A / \x1B are this module's internal sentinel bytes (shield
+    # tokens; _split_row's literal-pipe stand-in). Neither can occur
+    # in legitimate text (they are bare control bytes, never part of
+    # a UTF-8 sequence), so strip them up front: a user-typed token
+    # would otherwise be substituted -- or deleted -- by stage 9.
+    $body =~ tr/\x{1A}\x{1B}//d;
 
     my @shielded;
     my $shield = sub {
+        # token = \x1A M <index> M \x1A -- plain bytes that ride
+        # through Text::Markdown untouched. Restored in stage 9,
+        # BEFORE Board.pm's escape_tags sees the output.
         push @shielded, $_[0];
         return "\x{1A}M" . $#shielded . "M\x{1A}";
     };
 
-    # 1. fenced code blocks, at top level or inside blockquotes: an
-    #    optional uniform "> " prefix is captured, stripped from the code
-    #    lines, and re-emitted around the shield token so the rendered
-    #    block stays inside the quote
-    $body =~ s{^((?:>[ \t]?)*)```[ \t]*(\w*)[ \t]*\r?\n(.*?)^(?:>[ \t]?)*```[ \t]*\r?$}{
-        my ($pfx, $lang, $code) = ($1, $2, $3);
-        my $lvl = () = $pfx =~ /(>)/g;
+    # 1. fenced code blocks, at top level or inside blockquotes. The
+    #    OPENING line's "> " prefix sets the quote level; up to that
+    #    many quote markers are stripped from each code line ({0,$lvl}
+    #    -- at most the level, so a code line's own leading ">"
+    #    survives). The closing fence may sit at any quote level (lazy
+    #    continuation). The prefix is re-emitted around the token so
+    #    the block stays inside the quote; stage 6 removes the <p>
+    #    the parser wraps around the bare token line.
+    #    Info string: first word, lowercased, kept to prism's class
+    #    charset (word chars + . # -) so "c++", "c#", "objective-c"
+    #    all work; an unknown language degrades to an unstyled block.
+    $body =~ s{^((?:>[ \t]?)*)```[ \t]*([^`\r\n]*)\r?\n(.*?)^(?:>[ \t]?)*```[ \t]*\r?$}{
+        my ($pfx, $info, $code) = ($1, $2, $3);
+        my $lvl = _quote_level($pfx);
+        $lvl = 100 if $lvl > 100;   # perl {0,n} caps at 65534; no real quote nests past 100
+        my ($lang) = $info =~ /^\s*(\S+)/;
+        $lang = defined $lang ? lc $lang : '';
+        $lang =~ s/[^\w+.#-]//g;
         $code =~ s/\r//g;
         $code =~ s/^(?:>[ \t]?){0,$lvl}//mg if $lvl;
         $code =~ s/&/&amp;/g;
         $code =~ s/</&lt;/g;
         $code =~ s/>/&gt;/g;
+        # quotes escaped too: Board.pm's href strip must never match
+        # (and falsify) URLs merely DISPLAYED inside code
+        $code =~ s/"/&quot;/g;
+        $code =~ s/'/&#39;/g;
         $pfx . "\n" . $pfx
             . $shield->('<pre><code'
                         . ($lang ? qq{ class="language-$lang"} : '')
@@ -67,14 +118,30 @@ sub render {
             . "\n" . $pfx;
     }egms;
 
-    # 2. math spans; $$..$$ / \[..\] / \(..\) verbatim, then inline $..$
-    #    (pandoc rules: non-space inside, closing $ not followed by a
-    #    digit, single line -- keeps "$5 ... $10" as currency)
-    $body =~ s/(\$\$.+?\$\$|\\\[.+?\\\]|\\\(.+?\\\))/$shield->($1)/egs;
-    $body =~ s/(?<![\$\\])\$(?=\S)([^\$\n]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
+    # 2. math spans. Display forms are shielded verbatim; a span may
+    #    cross line breaks but never a BLANK line (client MathJax
+    #    cannot typeset across a paragraph break anyway) and never a
+    #    shield token -- so an unbalanced "$$" stays literal instead
+    #    of swallowing the headings, lists, or fences after it.
+    my $math = qr/(?:(?!\r?\n[ \t]*\r?\n)[^\x{1A}])+?/;
+    $body =~ s/(\$\$$math\$\$|\\\[$math\\\]|\\\($math\\\))/$shield->($1)/egs;
+    #    Inline $..$ -> \(..\), pandoc rules: non-space inside; the
+    #    opening $ not preceded by a digit (keeps postfix currency
+    #    "5$짜리 ... 10$짜리" as text) and the closing $ not followed
+    #    by one (prefix currency "$5 ... $10"); single line; content
+    #    free of $, backtick (one $..$ must not merge two `code
+    #    spans`).
+    $body =~ s/(?<![\$\\0-9])\$(?=\S)([^\$\n`]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
+    #    \$ = literal dollar (pandoc parity), unescaped now that real
+    #    math has been shielded
+    $body =~ s/\\\$/\$/g;
 
-    # 3. footnotes: collect top-level single-line definitions, then turn
-    #    references into numbered sup links (numbered by first reference)
+    # 3. footnotes: collect top-level single-line definitions, then
+    #    turn references into numbered sup links. Numbering is by
+    #    first reference. Anchors use the NUMBER, not the label:
+    #    byte-mode \w would strip a Korean label to "" (colliding
+    #    anchors), and $uniq keeps anchors distinct when several
+    #    articles render on one page.
     my (%fndef, @fnorder);
     $body =~ s{^\[\^([^\]\s]+)\]:[ \t]+(.+?)[ \t]*$}{
         $fndef{$1} = $2; '';
@@ -83,12 +150,12 @@ sub render {
         my %fnnum;
         $body =~ s{\[\^([^\]\s]+)\]}{
             if (exists $fndef{$1}) {
-                my $id = $1;
-                $fnnum{$id} ||= push @fnorder, $id;
-                (my $safe = $id) =~ s/[^\w-]//g;
-                qq{<sup id="fnref-$safe"><a href="#fn-$safe">$fnnum{$id}</a></sup>};
+                # first sight: push returns the new length of
+                # @fnorder, i.e. this footnote's 1-based number
+                my $n = $fnnum{$1} ||= push @fnorder, $1;
+                qq{<sup id="fnref-$uniq$n"><a href="#fn-$uniq$n">$n</a></sup>};
             } else {
-                "[^$1]";
+                "[^$1]";   # no such definition: leave it literal
             }
         }eg;
     }
@@ -99,30 +166,38 @@ sub render {
     # 5. classic markdown
     $body = Text::Markdown::markdown($body);
 
-    # 6. strikethrough outside code regions
+    # 6. a token holding BLOCK html (a fence) that ended up alone in a
+    #    paragraph: drop the invalid <p> wrapper (math tokens are
+    #    inline content and keep theirs)
+    $body =~ s{<p>(\x{1A}M(\d+)M\x{1A})</p>}{
+        my ($tok, $idx) = ($1, $2);   # the inner match below clobbers $1/$2
+        ($shielded[$idx] || '') =~ /^<pre>/ ? $tok : "<p>$tok</p>";
+    }eg;
+
+    # 7. strikethrough outside code regions
     $body = join '', map {
         /^<(?:pre|code)\b/i ? $_ : _del($_)
     } split /(<pre\b.*?<\/pre>|<code\b.*?<\/code>)/si, $body;
 
-    # 7. task lists (GFM): checkbox display only, bullet suppressed
-    $body =~ s{(<li>)(\s*<p>)?\s*\[([ xX])\]\s+}{
-        '<li style="list-style-type:none">' . ($2 || '')
+    # 8. task lists (GFM): checkbox display only, bullet suppressed
+    $body =~ s{<li>(\s*<p>)?\s*\[([ xX])\]\s+}{
+        '<li style="list-style-type:none">' . ($1 || '')
         . '<input type="checkbox" disabled'
-        . (lc($3) eq 'x' ? ' checked' : '') . '> '
+        . (lc($2) eq 'x' ? ' checked' : '') . '> '
     }eg;
 
-    # footnote list appended last (content may hold shielded math)
+    # 3b. the footnote list itself, appended last so its content may
+    #     hold shielded math (restored by stage 9 below)
     if (@fnorder) {
         my $fn = qq{<div class="footnotes"><hr /><ol>};
-        for my $id (@fnorder) {
-            (my $safe = $id) =~ s/[^\w-]//g;
-            $fn .= qq{<li id="fn-$safe">} . _cell_span($fndef{$id})
-                 . qq{ <a href="#fnref-$safe">&#8617;</a></li>};
+        for my $i (1 .. @fnorder) {
+            $fn .= qq{<li id="fn-$uniq$i">} . _span_md($fndef{$fnorder[$i-1]})
+                 . qq{ <a href="#fnref-$uniq$i">&#8617;</a></li>};
         }
         $body .= $fn . '</ol></div>';
     }
 
-    # 8. restore shielded spans
+    # 9. restore shielded spans
     $body =~ s/\x{1A}M(\d+)M\x{1A}/$shielded[$1]/g;
 
     return $body;
@@ -134,13 +209,25 @@ sub _del {
     return $t;
 }
 
-# span-level markdown for a table cell: render, unwrap the <p>
-sub _cell_span {
+# span-level markdown for a single-line fragment (table cells,
+# footnote definitions): render, unwrap the <p>
+sub _span_md {
     my $t = Text::Markdown::markdown($_[0]);
     $t =~ s/^\s*<p>//;
     $t =~ s/<\/p>\s*$//s;
     $t =~ s/\s+$//;
     return _del($t);
+}
+
+# "> > text" -> ("> > ", "text"); prefix is empty at top level
+sub _split_prefix {
+    my ($pfx, $rest) = $_[0] =~ /^((?:>[ \t]?)*)(.*)$/;
+    return ($pfx, $rest);
+}
+
+sub _quote_level {
+    my $n = () = $_[0] =~ />/g;
+    return $n;
 }
 
 sub _split_row {
@@ -157,53 +244,56 @@ sub _split_row {
     } split(/\|/, $r, -1);
 }
 
-sub _quote_level {
-    my $n = () = $_[0] =~ /(>)/g;
-    return $n;
-}
-
 sub _pipe_tables {
     my $body = shift;
     my @lines = split /\r?\n/, $body, -1;
     my @out;
     for (my $i = 0; $i <= $#lines; $i++) {
-        # tables work at top level (empty prefix) and inside blockquotes:
-        # all rows must sit at the same quote level, and the emitted
-        # <table> line keeps the prefix so it stays inside the quote
-        my ($pfx, $rest) = $lines[$i] =~ /^((?:>[ \t]?)*)(.*)$/;
-        my @hdr;
-        if ($rest =~ /\|/ && $i < $#lines && (@hdr = _split_row($rest))) {
-            my ($pfx2, $rest2) = $lines[$i+1] =~ /^((?:>[ \t]?)*)(.*)$/;
-            my @sep = ( _quote_level($pfx2) == _quote_level($pfx)
-                        && $rest2 =~ /\|/ ) ? _split_row($rest2) : ();
+        # tables work at top level (empty prefix) and inside
+        # blockquotes: all rows must sit at the same quote level, and
+        # the emitted <table> line keeps the prefix so it stays
+        # inside the quote
+        my ($pfx, $rest) = _split_prefix($lines[$i]);
+        if ($rest =~ /\|/ && $i < $#lines) {
+            # a lone "|" splits to an empty list -- not a table header
+            my @hdr = _split_row($rest);
+            my ($pfx2, $rest2) = _split_prefix($lines[$i+1]);
+            my @sep = (@hdr && $rest2 =~ /\|/
+                       && _quote_level($pfx2) == _quote_level($pfx))
+                      ? _split_row($rest2) : ();
             if (@sep && @sep == @hdr && !grep { !/^:?-+:?$/ } @sep) {
                 my @align = map {
                     /^:-*:$/ ? 'center' : /-:$/ ? 'right' : /^:/ ? 'left' : ''
                 } @sep;
-                my $attr = sub { $align[$_[0]] ? qq{ align="$align[$_[0]]"} : '' };
+                my $attr = sub {
+                    my ($col) = @_;
+                    return $align[$col] ? qq{ align="$align[$col]"} : '';
+                };
                 my $html = '<table><thead><tr>';
-                $html .= '<th' . $attr->($_) . '>' . _cell_span($hdr[$_]) . '</th>'
+                $html .= '<th' . $attr->($_) . '>' . _span_md($hdr[$_]) . '</th>'
                     for 0 .. $#hdr;
                 $html .= '</tr></thead><tbody>';
                 my $j = $i + 2;
                 while ($j <= $#lines) {
-                    my ($pj, $rj) = $lines[$j] =~ /^((?:>[ \t]?)*)(.*)$/;
+                    my ($pj, $rj) = _split_prefix($lines[$j]);
                     last unless _quote_level($pj) == _quote_level($pfx)
                              && $rj =~ /\|/;
                     my @row = _split_row($rj);
                     $html .= '<tr>';
                     $html .= '<td' . $attr->($_) . '>'
-                             . _cell_span(defined $row[$_] ? $row[$_] : '')
+                             . _span_md(defined $row[$_] ? $row[$_] : '')
                              . '</td>'
                         for 0 .. $#hdr;
                     $html .= '</tr>';
                     $j++;
                 }
                 $html .= '</tbody></table>';
-                # blank(-in-quote) lines around the block so Text::Markdown
-                # hashes it as raw block HTML instead of wrapping in <p>
+                # blank(-in-quote) lines around the block so
+                # Text::Markdown hashes it as raw block HTML instead
+                # of wrapping it in <p>
                 push @out, $pfx, $pfx . $html, $pfx;
-                $i = $j - 1;
+                $i = $j - 1;   # resume at $j, the first non-row line
+                               # (the for-loop's ++ lands there)
                 next;
             }
         }

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -148,11 +148,14 @@ sub render {
     #    pinned a worker for seconds per uncached view). $$ is symmetric
     #    (openers pair with each other), so it needs no exclusion and no
     #    length cap -- a formula of any size shields intact.
+    #    An escaped pair \\<char> is consumed as a unit FIRST, so the
+    #    LaTeX row break \\[1ex] (backslash-backslash-bracket, common in
+    #    matrix/aligned) is not mistaken for a nested \[ opener.
     my $nb = qr/(?!\r?\n[ \t]*\r?\n)/;
     $body =~ s{(
         \$\$ (?: $nb [^\x{1A}] )+? \$\$
-      | \\\[ (?: $nb (?! \\\[ ) [^\x{1A}] )+? \\\]
-      | \\\( (?: $nb (?! \\\( ) [^\x{1A}] )+? \\\)
+      | \\\[ (?: $nb (?: \\\\[^\x{1A}] | (?!\\\[) [^\x{1A}] ) )+? \\\]
+      | \\\( (?: $nb (?: \\\\[^\x{1A}] | (?!\\\() [^\x{1A}] ) )+? \\\)
     )}{$shield->($1)}egsx;
     #    Inline $..$ -> \(..\), pandoc rules: non-space inside; the
     #    opening $ not preceded by a digit (keeps postfix currency
@@ -249,18 +252,21 @@ sub _del {
 # `~~x~~` in a code span stays literal. Used by stage 7 and _span_md
 # (a cell/footnote-def may hold an inline <code> span too). A ~~ pair
 # cannot span a code region -- the split breaks it (documented limit).
-# The region body excludes further <pre/<code OPENERS so a dangling
-# (unclosed) one fails at the next opener instead of scanning to end of
-# string from every opener -- else this is the same O(n^2) stored ReDoS
-# as the math stage (a body of unclosed "<code" is plantable, since
-# escape_tags does not denylist pre/code).
+# A region body excludes its OWN further opener so a dangling (unclosed)
+# one fails at the next opener instead of scanning to end of string from
+# every opener -- else this is the same O(n^2) stored ReDoS as the math
+# stage (a body of unclosed "<code" is plantable, since escape_tags does
+# not denylist pre/code). It must NOT exclude the sibling opener: a
+# <pre> body legitimately contains a nested <code> (the canonical
+# <pre><code>..</code></pre> shape), which must be captured as one
+# region so ~~ after the inner </code> stays literal.
 sub _del_outside_code {
     my $t = shift;
     return join '', map {
         /^<(?:pre|code)\b/i ? $_ : _del($_)
     } split /(
-        <pre\b  (?: (?! <pre\b ) (?! <code\b ) . )*? <\/pre>
-      | <code\b (?: (?! <code\b ) (?! <pre\b ) . )*? <\/code>
+        <pre\b  (?: (?! <pre\b ) . )*? <\/pre>
+      | <code\b (?: (?! <code\b ) . )*? <\/code>
     )/six, $t;
 }
 

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -160,7 +160,13 @@ sub render {
     #    line would eat the first newline and the span would cross the
     #    paragraph break (the $nb guard is per-iteration, so a blank
     #    line must always fall to the one-char alternative to be seen).
-    my $nb = qr/(?!(?:\r\n?|\n)[ \t]*(?:\r\n?|\n))/;   # not a blank line (LF/CRLF/bare-CR)
+    # not a blank line. Atomic (?>...) is load-bearing: a plain
+    # (?:\r\n?|\n) lets a single CRLF re-split (\r matches, backtracks to
+    # give up \n, second alt takes the \n) so one CRLF would read as a
+    # blank line and wrongly block a normal multi-line formula. The
+    # atomic group forbids that backtrack, so CRLF is one indivisible
+    # ending -- matching LF, CRLF, and bare-CR blank lines, none else.
+    my $nb = qr/(?!(?>\r\n?|\n)[ \t]*(?>\r\n?|\n))/;
     $body =~ s{(
         \$\$ (?: $nb [^\x{1A}] )+? \$\$
       | \\\[ (?: $nb (?: \\\\[^\x{1A}\r\n] | (?!\\\[) [^\x{1A}] ) )+? \\\]

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -43,6 +43,9 @@ package Bawi::Markdown;
 #     code at top level (that needs real block parsing). 8-space-
 #     indented code inside a list item is native classic markdown and
 #     works.
+#   - blockquote nesting is capped at 32 levels (excess '>' markers are
+#     dropped) to bound Text::Markdown's super-linear deep-quote cost; no
+#     real quote nests that deep
 #   - footnote definitions are top-level and single-line
 #   - a pipe-table lookalike inside 4-space-indented code is parsed as
 #     a table (use a ``` fence for code instead)
@@ -93,6 +96,15 @@ sub render {
     # a UTF-8 sequence), so strip them up front: a user-typed token
     # would otherwise be substituted -- or deleted -- by stage 9.
     $body =~ tr/\x{1A}\x{1B}//d;
+
+    # Cap blockquote nesting depth. Text::Markdown's _DoBlockQuotes
+    # recurses once per '>' level and re-processes the cumulative HTML at
+    # each level, so deep nesting is super-linear (a crafted 200-deep
+    # quote took ~20s per uncached render -- a stored DoS). Real quoting
+    # is never more than a few deep; clamp a leading run of '>' markers to
+    # 32, dropping the excess. Linear one-pass; downstream stages then
+    # never see more than 32 levels.
+    $body =~ s/^((?:>[ \t]?){32})(?:>[ \t]?)+/$1/mg;
 
     my @shielded;
     my $shield = sub {

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -61,7 +61,11 @@ package Bawi::Markdown;
 #     since its content excludes backticks)
 #   - an odd number of $$ within one paragraph mis-pairs: a stray $$
 #     grabs the opening $$ of the next real display span (unbalanced-
-#     delimiter matching, no balance tracking)
+#     delimiter matching, no balance tracking). Likewise a \[..\] /
+#     \(..\) whose content ends in a backslash, when an UNBALANCED
+#     same-family closer sits further downstream, can over-shield to
+#     that stray closer. Both are malformed-input only; well-formed
+#     (balanced) math is unaffected.
 #   - a literal $$..$$ typed as \$\$..\$\$ still renders as display
 #     math (the \$ unescape re-forms $$); there is no way to show a
 #     literal $$ pair in markdown mode
@@ -150,12 +154,16 @@ sub render {
     #    length cap -- a formula of any size shields intact.
     #    An escaped pair \\<char> is consumed as a unit FIRST, so the
     #    LaTeX row break \\[1ex] (backslash-backslash-bracket, common in
-    #    matrix/aligned) is not mistaken for a nested \[ opener.
+    #    matrix/aligned) is not mistaken for a nested \[ opener. That
+    #    trailing char excludes \r\n: otherwise \\ right before a blank
+    #    line would eat the first newline and the span would cross the
+    #    paragraph break (the $nb guard is per-iteration, so a blank
+    #    line must always fall to the one-char alternative to be seen).
     my $nb = qr/(?!\r?\n[ \t]*\r?\n)/;
     $body =~ s{(
         \$\$ (?: $nb [^\x{1A}] )+? \$\$
-      | \\\[ (?: $nb (?: \\\\[^\x{1A}] | (?!\\\[) [^\x{1A}] ) )+? \\\]
-      | \\\( (?: $nb (?: \\\\[^\x{1A}] | (?!\\\() [^\x{1A}] ) )+? \\\)
+      | \\\[ (?: $nb (?: \\\\[^\x{1A}\r\n] | (?!\\\[) [^\x{1A}] ) )+? \\\]
+      | \\\( (?: $nb (?: \\\\[^\x{1A}\r\n] | (?!\\\() [^\x{1A}] ) )+? \\\)
     )}{$shield->($1)}egsx;
     #    Inline $..$ -> \(..\), pandoc rules: non-space inside; the
     #    opening $ not preceded by a digit (keeps postfix currency

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -142,7 +142,8 @@ sub render {
 
     # 2. math spans. Display forms are shielded verbatim; a span may
     #    cross line breaks but never a BLANK line (client MathJax cannot
-    #    typeset across a paragraph break anyway -- $nb below) and never
+    #    typeset across a paragraph break anyway -- $nb below, which
+    #    recognizes LF, CRLF, and bare-CR blank lines) and never
     #    a shield token (\x1A) -- so an unbalanced delimiter stays
     #    literal instead of swallowing the headings/lists/fences after
     #    it. The asymmetric forms \(..\) and \[..\] additionally exclude
@@ -159,7 +160,7 @@ sub render {
     #    line would eat the first newline and the span would cross the
     #    paragraph break (the $nb guard is per-iteration, so a blank
     #    line must always fall to the one-char alternative to be seen).
-    my $nb = qr/(?!\r?\n[ \t]*\r?\n)/;
+    my $nb = qr/(?!(?:\r\n?|\n)[ \t]*(?:\r\n?|\n))/;   # not a blank line (LF/CRLF/bare-CR)
     $body =~ s{(
         \$\$ (?: $nb [^\x{1A}] )+? \$\$
       | \\\[ (?: $nb (?: \\\\[^\x{1A}\r\n] | (?!\\\[) [^\x{1A}] ) )+? \\\]

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -24,15 +24,16 @@ package Bawi::Markdown;
 #   here -- Bawi::Board::format_article applies it after render(), so
 #   math/fence/table content passes the same denylist as everything else.
 #
-# ponytail ceilings (v1): fences/tables/footnote-definitions are
-# recognized at top level only (not inside lists/blockquotes -- note that
-# 8-space-indented code inside a list item is native classic markdown and
-# already works); a pipe-table lookalike inside 4-space indented code is
+# ponytail ceilings (v1): fences/tables work at top level and inside
+# blockquotes, but NOT inside list items -- that would need real block-
+# structure parsing (4-space indent inside a list item already means
+# "code block" in classic markdown); 8-space-indented code inside a list
+# item is native and works. Footnote definitions are top-level and
+# single-line. A pipe-table lookalike inside 4-space indented code is
 # parsed as a table (use a ``` fence for code instead); escape a literal
 # | in a table cell as \|; a single $..$ can eat a | if one math span is
 # written across two cells; $..$ and [^ref] inside inline `code spans`
-# and 4-space blocks are still transformed (fences are fully immune);
-# footnote definitions are single-line.
+# and 4-space blocks are still transformed (fences are fully immune).
 use strict;
 use warnings;
 use Text::Markdown;
@@ -47,16 +48,23 @@ sub render {
         return "\x{1A}M" . $#shielded . "M\x{1A}";
     };
 
-    # 1. fenced code blocks
-    $body =~ s{^```[ \t]*(\w*)[ \t]*\r?\n(.*?)^```[ \t]*\r?$}{
-        my ($lang, $code) = ($1, $2);
+    # 1. fenced code blocks, at top level or inside blockquotes: an
+    #    optional uniform "> " prefix is captured, stripped from the code
+    #    lines, and re-emitted around the shield token so the rendered
+    #    block stays inside the quote
+    $body =~ s{^((?:>[ \t]?)*)```[ \t]*(\w*)[ \t]*\r?\n(.*?)^(?:>[ \t]?)*```[ \t]*\r?$}{
+        my ($pfx, $lang, $code) = ($1, $2, $3);
+        my $lvl = () = $pfx =~ /(>)/g;
         $code =~ s/\r//g;
+        $code =~ s/^(?:>[ \t]?){0,$lvl}//mg if $lvl;
         $code =~ s/&/&amp;/g;
         $code =~ s/</&lt;/g;
         $code =~ s/>/&gt;/g;
-        $shield->('<pre><code'
-                  . ($lang ? qq{ class="language-$lang"} : '')
-                  . '>' . $code . '</code></pre>');
+        $pfx . "\n" . $pfx
+            . $shield->('<pre><code'
+                        . ($lang ? qq{ class="language-$lang"} : '')
+                        . '>' . $code . '</code></pre>')
+            . "\n" . $pfx;
     }egms;
 
     # 2. math spans; $$..$$ / \[..\] / \(..\) verbatim, then inline $..$
@@ -149,16 +157,26 @@ sub _split_row {
     } split(/\|/, $r, -1);
 }
 
+sub _quote_level {
+    my $n = () = $_[0] =~ /(>)/g;
+    return $n;
+}
+
 sub _pipe_tables {
     my $body = shift;
     my @lines = split /\r?\n/, $body, -1;
     my @out;
     for (my $i = 0; $i <= $#lines; $i++) {
+        # tables work at top level (empty prefix) and inside blockquotes:
+        # all rows must sit at the same quote level, and the emitted
+        # <table> line keeps the prefix so it stays inside the quote
+        my ($pfx, $rest) = $lines[$i] =~ /^((?:>[ \t]?)*)(.*)$/;
         my @hdr;
-        if ($lines[$i] =~ /\|/ && $i < $#lines && $lines[$i+1] =~ /\|/
-            && (@hdr = _split_row($lines[$i]))) {
-            my @sep = _split_row($lines[$i+1]);
-            if (@sep == @hdr && @sep && !grep { !/^:?-+:?$/ } @sep) {
+        if ($rest =~ /\|/ && $i < $#lines && (@hdr = _split_row($rest))) {
+            my ($pfx2, $rest2) = $lines[$i+1] =~ /^((?:>[ \t]?)*)(.*)$/;
+            my @sep = ( _quote_level($pfx2) == _quote_level($pfx)
+                        && $rest2 =~ /\|/ ) ? _split_row($rest2) : ();
+            if (@sep && @sep == @hdr && !grep { !/^:?-+:?$/ } @sep) {
                 my @align = map {
                     /^:-*:$/ ? 'center' : /-:$/ ? 'right' : /^:/ ? 'left' : ''
                 } @sep;
@@ -168,8 +186,11 @@ sub _pipe_tables {
                     for 0 .. $#hdr;
                 $html .= '</tr></thead><tbody>';
                 my $j = $i + 2;
-                while ($j <= $#lines && $lines[$j] =~ /\|/) {
-                    my @row = _split_row($lines[$j]);
+                while ($j <= $#lines) {
+                    my ($pj, $rj) = $lines[$j] =~ /^((?:>[ \t]?)*)(.*)$/;
+                    last unless _quote_level($pj) == _quote_level($pfx)
+                             && $rj =~ /\|/;
+                    my @row = _split_row($rj);
                     $html .= '<tr>';
                     $html .= '<td' . $attr->($_) . '>'
                              . _cell_span(defined $row[$_] ? $row[$_] : '')
@@ -179,9 +200,9 @@ sub _pipe_tables {
                     $j++;
                 }
                 $html .= '</tbody></table>';
-                # blank lines around the block so Text::Markdown hashes it
-                # as raw block HTML instead of wrapping it in <p>
-                push @out, '', $html, '';
+                # blank(-in-quote) lines around the block so Text::Markdown
+                # hashes it as raw block HTML instead of wrapping in <p>
+                push @out, $pfx, $pfx . $html, $pfx;
                 $i = $j - 1;
                 next;
             }

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -11,21 +11,28 @@ package Bawi::Markdown;
 #        from the parser; inline $..$ is emitted as \(..\) because the
 #        site MathJax config (TeX-MML-AM_CHTML) has single-$ off but
 #        already processes \(..\) -- no client config change
-#     3. GFM pipe tables -> <table> (Text::Markdown passes block-level
+#     3. footnotes: [^id] references + top-level "[^id]: text"
+#        definitions -> numbered <sup> links and a trailing footnote list
+#     4. GFM pipe tables -> <table> (Text::Markdown passes block-level
 #        HTML through untouched; cell contents get span-level markdown)
-#     4. Text::Markdown::markdown()
-#     5. ~~strikethrough~~ -> <del>, skipping <pre>/<code> regions
-#     6. shielded spans restored verbatim
+#     5. Text::Markdown::markdown()
+#     6. ~~strikethrough~~ -> <del>, skipping <pre>/<code> regions
+#     7. task lists: <li>[ ] / <li>[x] -> disabled checkboxes
+#     8. shielded spans restored verbatim
 #
 #   Sanitization (escape_tags denylist, href scheme strip) is NOT done
 #   here -- Bawi::Board::format_article applies it after render(), so
 #   math/fence/table content passes the same denylist as everything else.
 #
-# ponytail ceilings (v1): fences/tables are recognized at top level only
-# (not inside lists/blockquotes); a pipe-table lookalike inside 4-space
-# indented code is parsed as a table (use a ``` fence for code instead);
-# escape a literal | in a table cell as \|; a single $..$ can eat a |
-# if one math span is written across two cells.
+# ponytail ceilings (v1): fences/tables/footnote-definitions are
+# recognized at top level only (not inside lists/blockquotes -- note that
+# 8-space-indented code inside a list item is native classic markdown and
+# already works); a pipe-table lookalike inside 4-space indented code is
+# parsed as a table (use a ``` fence for code instead); escape a literal
+# | in a table cell as \|; a single $..$ can eat a | if one math span is
+# written across two cells; $..$ and [^ref] inside inline `code spans`
+# and 4-space blocks are still transformed (fences are fully immune);
+# footnote definitions are single-line.
 use strict;
 use warnings;
 use Text::Markdown;
@@ -58,18 +65,56 @@ sub render {
     $body =~ s/(\$\$.+?\$\$|\\\[.+?\\\]|\\\(.+?\\\))/$shield->($1)/egs;
     $body =~ s/(?<![\$\\])\$(?=\S)([^\$\n]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
 
-    # 3. pipe tables
+    # 3. footnotes: collect top-level single-line definitions, then turn
+    #    references into numbered sup links (numbered by first reference)
+    my (%fndef, @fnorder);
+    $body =~ s{^\[\^([^\]\s]+)\]:[ \t]+(.+?)[ \t]*$}{
+        $fndef{$1} = $2; '';
+    }egm;
+    if (%fndef) {
+        my %fnnum;
+        $body =~ s{\[\^([^\]\s]+)\]}{
+            if (exists $fndef{$1}) {
+                my $id = $1;
+                $fnnum{$id} ||= push @fnorder, $id;
+                (my $safe = $id) =~ s/[^\w-]//g;
+                qq{<sup id="fnref-$safe"><a href="#fn-$safe">$fnnum{$id}</a></sup>};
+            } else {
+                "[^$1]";
+            }
+        }eg;
+    }
+
+    # 4. pipe tables
     $body = _pipe_tables($body);
 
-    # 4. classic markdown
+    # 5. classic markdown
     $body = Text::Markdown::markdown($body);
 
-    # 5. strikethrough outside code regions
+    # 6. strikethrough outside code regions
     $body = join '', map {
         /^<(?:pre|code)\b/i ? $_ : _del($_)
     } split /(<pre\b.*?<\/pre>|<code\b.*?<\/code>)/si, $body;
 
-    # 6. restore shielded spans
+    # 7. task lists (GFM): checkbox display only, bullet suppressed
+    $body =~ s{(<li>)(\s*<p>)?\s*\[([ xX])\]\s+}{
+        '<li style="list-style-type:none">' . ($2 || '')
+        . '<input type="checkbox" disabled'
+        . (lc($3) eq 'x' ? ' checked' : '') . '> '
+    }eg;
+
+    # footnote list appended last (content may hold shielded math)
+    if (@fnorder) {
+        my $fn = qq{<div class="footnotes"><hr /><ol>};
+        for my $id (@fnorder) {
+            (my $safe = $id) =~ s/[^\w-]//g;
+            $fn .= qq{<li id="fn-$safe">} . _cell_span($fndef{$id})
+                 . qq{ <a href="#fnref-$safe">&#8617;</a></li>};
+        }
+        $body .= $fn . '</ol></div>';
+    }
+
+    # 8. restore shielded spans
     $body =~ s/\x{1A}M(\d+)M\x{1A}/$shielded[$1]/g;
 
     return $body;

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -50,14 +50,25 @@ package Bawi::Markdown;
 #   - table cells and footnote definitions are span-level context:
 #     reference-style links do not resolve there, and block syntax in
 #     a cell degrades
+#   - a $..$ span across two cells of one table row consumes the pipe;
+#     the row then mismatches the separator and the table degrades to
+#     a paragraph. Write literal dollars in table rows as \$.
 #   - $..$ / [^ref] sitting entirely inside ONE inline `code span` or
 #     a 4-space indented block are still transformed (``` fences are
 #     fully immune; an inline $..$ can no longer MERGE two code spans,
 #     since its content excludes backticks)
+#   - an odd number of $$ within one paragraph mis-pairs: a stray $$
+#     grabs the opening $$ of the next real display span (unbalanced-
+#     delimiter matching, no balance tracking)
+#   - a literal $$..$$ typed as \$\$..\$\$ still renders as display
+#     math (the \$ unescape re-forms $$); there is no way to show a
+#     literal $$ pair in markdown mode
+#   - ONLY exactly ``` opens a fence; a 4+-backtick fence is not
+#     recognized
 #   - a fence's closing ``` may sit at any quote level (lazy
 #     continuation); the opening line's prefix decides the strip level
-#   - ~~..~~ inside a tag attribute (a URL containing two ~~ runs) is
-#     still rewritten
+#   - ~~..~~ cannot span an inline `code span` or a tag attribute (the
+#     pair is split at code-region/tag boundaries and left literal)
 
 use strict;
 use warnings;
@@ -92,16 +103,19 @@ sub render {
     #    continuation). The prefix is re-emitted around the token so
     #    the block stays inside the quote; stage 6 removes the <p>
     #    the parser wraps around the bare token line.
-    #    Info string: first word, lowercased, kept to prism's class
-    #    charset (word chars + . # -) so "c++", "c#", "objective-c"
-    #    all work; an unknown language degrades to an unstyled block.
+    #    Info string: first word, lowercased. prism's own language
+    #    regex is /-([\w-]+)/, which would truncate "c++"/"c#" to "c",
+    #    so map those to prism's canonical grammar names; other tags
+    #    are kept to [\w.-] and an unknown one degrades to an unstyled
+    #    block. Only exactly ``` opens a fence (4+ backticks do not).
     $body =~ s{^((?:>[ \t]?)*)```[ \t]*([^`\r\n]*)\r?\n(.*?)^(?:>[ \t]?)*```[ \t]*\r?$}{
         my ($pfx, $info, $code) = ($1, $2, $3);
         my $lvl = _quote_level($pfx);
         $lvl = 100 if $lvl > 100;   # perl {0,n} caps at 65534; no real quote nests past 100
         my ($lang) = $info =~ /^\s*(\S+)/;
         $lang = defined $lang ? lc $lang : '';
-        $lang =~ s/[^\w+.#-]//g;
+        $lang = $lang eq 'c++' ? 'cpp' : $lang eq 'c#' ? 'csharp' : $lang;
+        $lang =~ s/[^\w.-]//g;
         $code =~ s/\r//g;
         $code =~ s/^(?:>[ \t]?){0,$lvl}//mg if $lvl;
         $code =~ s/&/&amp;/g;
@@ -123,17 +137,35 @@ sub render {
     #    cannot typeset across a paragraph break anyway) and never a
     #    shield token -- so an unbalanced "$$" stays literal instead
     #    of swallowing the headings, lists, or fences after it.
-    my $math = qr/(?:(?!\r?\n[ \t]*\r?\n)[^\x{1A}])+?/;
-    $body =~ s/(\$\$$math\$\$|\\\[$math\\\]|\\\($math\\\))/$shield->($1)/egs;
+    #    The span is length-bounded, and a branch is tried only when
+    #    its CLOSING delimiter is present: the three distinct closers
+    #    ($$, ], ")") defeat perl's fast-fail optimizer, so WITHOUT
+    #    these two guards a body full of unmatched openers is an
+    #    O(n^2) scan -- a stored ReDoS (a 64 KB article of "\(" pinned
+    #    a worker ~37s per uncached view). A real formula is nowhere
+    #    near 2000 chars.
+    my $span = qr/(?:(?!\r?\n[ \t]*\r?\n)[^\x{1A}]){1,2000}?/;
+    my @disp;
+    push @disp, qr/\$\$$span\$\$/ if index($body, '$$') >= 0;
+    push @disp, qr/\\\[$span\\\]/ if index($body, '\]') >= 0;   # closer: \]
+    push @disp, qr/\\\($span\\\)/ if index($body, '\)') >= 0;   # closer: \)
+    if (@disp) {
+        my $disp = join '|', @disp;
+        $body =~ s/($disp)/$shield->($1)/egs;
+    }
     #    Inline $..$ -> \(..\), pandoc rules: non-space inside; the
     #    opening $ not preceded by a digit (keeps postfix currency
     #    "5$짜리 ... 10$짜리" as text) and the closing $ not followed
     #    by one (prefix currency "$5 ... $10"); single line; content
     #    free of $, backtick (one $..$ must not merge two `code
-    #    spans`).
-    $body =~ s/(?<![\$\\0-9])\$(?=\S)([^\$\n`]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
+    #    spans`), and the shield byte \x1A (so an inline pair wrapping
+    #    an already-shielded display token cannot nest -- the one-pass
+    #    restore in stage 9 would otherwise leak the sentinel).
+    $body =~ s/(?<![\$\\0-9])\$(?=\S)([^\$\n`\x{1A}]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
     #    \$ = literal dollar (pandoc parity), unescaped now that real
-    #    math has been shielded
+    #    math has been shielded. (A literal $$..$$ typed as \$\$..\$\$
+    #    still becomes $$..$$ and WILL render as display math -- see
+    #    the limitations list.)
     $body =~ s/\\\$/\$/g;
 
     # 3. footnotes: collect top-level single-line definitions, then
@@ -147,13 +179,18 @@ sub render {
         $fndef{$1} = $2; '';
     }egm;
     if (%fndef) {
-        my %fnnum;
+        my (%fnnum, %fnseen);
         $body =~ s{\[\^([^\]\s]+)\]}{
             if (exists $fndef{$1}) {
                 # first sight: push returns the new length of
                 # @fnorder, i.e. this footnote's 1-based number
                 my $n = $fnnum{$1} ||= push @fnorder, $1;
-                qq{<sup id="fnref-$uniq$n"><a href="#fn-$uniq$n">$n</a></sup>};
+                # a label cited more than once must not repeat the ref
+                # id (invalid HTML); suffix repeats fnref-<n>-2, -3...
+                # The definition's backlink points at the first cite.
+                my $k = ++$fnseen{$1};
+                my $refid = $k == 1 ? "fnref-$uniq$n" : "fnref-$uniq$n-$k";
+                qq{<sup id="$refid"><a href="#fn-$uniq$n">$n</a></sup>};
             } else {
                 "[^$1]";   # no such definition: leave it literal
             }
@@ -175,9 +212,7 @@ sub render {
     }eg;
 
     # 7. strikethrough outside code regions
-    $body = join '', map {
-        /^<(?:pre|code)\b/i ? $_ : _del($_)
-    } split /(<pre\b.*?<\/pre>|<code\b.*?<\/code>)/si, $body;
+    $body = _del_outside_code($body);
 
     # 8. task lists (GFM): checkbox display only, bullet suppressed
     $body =~ s{<li>(\s*<p>)?\s*\[([ xX])\]\s+}{
@@ -209,6 +244,17 @@ sub _del {
     return $t;
 }
 
+# ~~strikethrough~~ everywhere EXCEPT inside <pre>/<code> regions, so
+# `~~x~~` in a code span stays literal. Used by stage 7 and _span_md
+# (a cell/footnote-def may hold an inline <code> span too). A ~~ pair
+# cannot span a code region -- the split breaks it (documented limit).
+sub _del_outside_code {
+    my $t = shift;
+    return join '', map {
+        /^<(?:pre|code)\b/i ? $_ : _del($_)
+    } split /(<pre\b.*?<\/pre>|<code\b.*?<\/code>)/si, $t;
+}
+
 # span-level markdown for a single-line fragment (table cells,
 # footnote definitions): render, unwrap the <p>
 sub _span_md {
@@ -216,7 +262,7 @@ sub _span_md {
     $t =~ s/^\s*<p>//;
     $t =~ s/<\/p>\s*$//s;
     $t =~ s/\s+$//;
-    return _del($t);
+    return _del_outside_code($t);
 }
 
 # "> > text" -> ("> > ", "text"); prefix is empty at top level

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -1,0 +1,149 @@
+package Bawi::Markdown;
+# Markdown rendering pipeline for category==1 articles: classic
+# Text::Markdown plus the extensions the board wants on top of it.
+#
+#   render($body) does, in order:
+#     1. ``` fenced code blocks -> <pre><code class="language-X">
+#        (classic Markdown only knows 4-space indentation; fences are
+#        extracted first so nothing inside code is ever taken for math,
+#        a table, or markup; prism.js in the skin does the highlighting)
+#     2. MathJax spans ($$..$$ \[..\] \(..\) and inline $..$) shielded
+#        from the parser; inline $..$ is emitted as \(..\) because the
+#        site MathJax config (TeX-MML-AM_CHTML) has single-$ off but
+#        already processes \(..\) -- no client config change
+#     3. GFM pipe tables -> <table> (Text::Markdown passes block-level
+#        HTML through untouched; cell contents get span-level markdown)
+#     4. Text::Markdown::markdown()
+#     5. ~~strikethrough~~ -> <del>, skipping <pre>/<code> regions
+#     6. shielded spans restored verbatim
+#
+#   Sanitization (escape_tags denylist, href scheme strip) is NOT done
+#   here -- Bawi::Board::format_article applies it after render(), so
+#   math/fence/table content passes the same denylist as everything else.
+#
+# ponytail ceilings (v1): fences/tables are recognized at top level only
+# (not inside lists/blockquotes); a pipe-table lookalike inside 4-space
+# indented code is parsed as a table (use a ``` fence for code instead);
+# escape a literal | in a table cell as \|; a single $..$ can eat a |
+# if one math span is written across two cells.
+use strict;
+use warnings;
+use Text::Markdown;
+
+sub render {
+    my $body = shift;
+    return $body unless defined $body;
+
+    my @shielded;
+    my $shield = sub {
+        push @shielded, $_[0];
+        return "\x{1A}M" . $#shielded . "M\x{1A}";
+    };
+
+    # 1. fenced code blocks
+    $body =~ s{^```[ \t]*(\w*)[ \t]*\r?\n(.*?)^```[ \t]*\r?$}{
+        my ($lang, $code) = ($1, $2);
+        $code =~ s/\r//g;
+        $code =~ s/&/&amp;/g;
+        $code =~ s/</&lt;/g;
+        $code =~ s/>/&gt;/g;
+        $shield->('<pre><code'
+                  . ($lang ? qq{ class="language-$lang"} : '')
+                  . '>' . $code . '</code></pre>');
+    }egms;
+
+    # 2. math spans; $$..$$ / \[..\] / \(..\) verbatim, then inline $..$
+    #    (pandoc rules: non-space inside, closing $ not followed by a
+    #    digit, single line -- keeps "$5 ... $10" as currency)
+    $body =~ s/(\$\$.+?\$\$|\\\[.+?\\\]|\\\(.+?\\\))/$shield->($1)/egs;
+    $body =~ s/(?<![\$\\])\$(?=\S)([^\$\n]+?)(?<=\S)\$(?!\d)/$shield->("\\($1\\)")/eg;
+
+    # 3. pipe tables
+    $body = _pipe_tables($body);
+
+    # 4. classic markdown
+    $body = Text::Markdown::markdown($body);
+
+    # 5. strikethrough outside code regions
+    $body = join '', map {
+        /^<(?:pre|code)\b/i ? $_ : _del($_)
+    } split /(<pre\b.*?<\/pre>|<code\b.*?<\/code>)/si, $body;
+
+    # 6. restore shielded spans
+    $body =~ s/\x{1A}M(\d+)M\x{1A}/$shielded[$1]/g;
+
+    return $body;
+}
+
+sub _del {
+    my $t = shift;
+    $t =~ s/(?<!~)~~(?=\S)(.+?)(?<=\S)~~(?!~)/<del>$1<\/del>/g;
+    return $t;
+}
+
+# span-level markdown for a table cell: render, unwrap the <p>
+sub _cell_span {
+    my $t = Text::Markdown::markdown($_[0]);
+    $t =~ s/^\s*<p>//;
+    $t =~ s/<\/p>\s*$//s;
+    $t =~ s/\s+$//;
+    return _del($t);
+}
+
+sub _split_row {
+    my $r = shift;
+    $r =~ s/^\s*\|//;
+    $r =~ s/\|\s*$//;
+    $r =~ s/\\\|/\x{1B}/g;    # \| = literal pipe inside a cell
+    return map {
+        my $c = $_;
+        $c =~ s/\x{1B}/|/g;
+        $c =~ s/^\s+//;
+        $c =~ s/\s+$//;
+        $c;
+    } split(/\|/, $r, -1);
+}
+
+sub _pipe_tables {
+    my $body = shift;
+    my @lines = split /\r?\n/, $body, -1;
+    my @out;
+    for (my $i = 0; $i <= $#lines; $i++) {
+        my @hdr;
+        if ($lines[$i] =~ /\|/ && $i < $#lines && $lines[$i+1] =~ /\|/
+            && (@hdr = _split_row($lines[$i]))) {
+            my @sep = _split_row($lines[$i+1]);
+            if (@sep == @hdr && @sep && !grep { !/^:?-+:?$/ } @sep) {
+                my @align = map {
+                    /^:-*:$/ ? 'center' : /-:$/ ? 'right' : /^:/ ? 'left' : ''
+                } @sep;
+                my $attr = sub { $align[$_[0]] ? qq{ align="$align[$_[0]]"} : '' };
+                my $html = '<table><thead><tr>';
+                $html .= '<th' . $attr->($_) . '>' . _cell_span($hdr[$_]) . '</th>'
+                    for 0 .. $#hdr;
+                $html .= '</tr></thead><tbody>';
+                my $j = $i + 2;
+                while ($j <= $#lines && $lines[$j] =~ /\|/) {
+                    my @row = _split_row($lines[$j]);
+                    $html .= '<tr>';
+                    $html .= '<td' . $attr->($_) . '>'
+                             . _cell_span(defined $row[$_] ? $row[$_] : '')
+                             . '</td>'
+                        for 0 .. $#hdr;
+                    $html .= '</tr>';
+                    $j++;
+                }
+                $html .= '</tbody></table>';
+                # blank lines around the block so Text::Markdown hashes it
+                # as raw block HTML instead of wrapping it in <p>
+                push @out, '', $html, '';
+                $i = $j - 1;
+                next;
+            }
+        }
+        push @out, $lines[$i];
+    }
+    return join("\n", @out);
+}
+
+1;

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -51,8 +51,10 @@ package Bawi::Markdown;
 #     reference-style links do not resolve there, and block syntax in
 #     a cell degrades
 #   - a $..$ span across two cells of one table row consumes the pipe;
-#     the row then mismatches the separator and the table degrades to
-#     a paragraph. Write literal dollars in table rows as \$.
+#     in the HEADER row the column count then mismatches the separator
+#     and the whole table degrades to a paragraph, in a BODY row the
+#     table survives with a mangled row. Write literal dollars in table
+#     rows as \$.
 #   - $..$ / [^ref] sitting entirely inside ONE inline `code span` or
 #     a 4-space indented block are still transformed (``` fences are
 #     fully immune; an inline $..$ can no longer MERGE two code spans,
@@ -67,8 +69,10 @@ package Bawi::Markdown;
 #     recognized
 #   - a fence's closing ``` may sit at any quote level (lazy
 #     continuation); the opening line's prefix decides the strip level
-#   - ~~..~~ cannot span an inline `code span` or a tag attribute (the
-#     pair is split at code-region/tag boundaries and left literal)
+#   - ~~..~~ cannot span an inline `code span` (the pair is split at
+#     code-region boundaries and left literal). A ~~a~~ pair INSIDE a
+#     tag attribute / URL is still rewritten to <del>, corrupting the
+#     attribute -- write such URLs without paired tildes.
 
 use strict;
 use warnings;
@@ -133,26 +137,23 @@ sub render {
     }egms;
 
     # 2. math spans. Display forms are shielded verbatim; a span may
-    #    cross line breaks but never a BLANK line (client MathJax
-    #    cannot typeset across a paragraph break anyway) and never a
-    #    shield token -- so an unbalanced "$$" stays literal instead
-    #    of swallowing the headings, lists, or fences after it.
-    #    The span is length-bounded, and a branch is tried only when
-    #    its CLOSING delimiter is present: the three distinct closers
-    #    ($$, ], ")") defeat perl's fast-fail optimizer, so WITHOUT
-    #    these two guards a body full of unmatched openers is an
-    #    O(n^2) scan -- a stored ReDoS (a 64 KB article of "\(" pinned
-    #    a worker ~37s per uncached view). A real formula is nowhere
-    #    near 2000 chars.
-    my $span = qr/(?:(?!\r?\n[ \t]*\r?\n)[^\x{1A}]){1,2000}?/;
-    my @disp;
-    push @disp, qr/\$\$$span\$\$/ if index($body, '$$') >= 0;
-    push @disp, qr/\\\[$span\\\]/ if index($body, '\]') >= 0;   # closer: \]
-    push @disp, qr/\\\($span\\\)/ if index($body, '\)') >= 0;   # closer: \)
-    if (@disp) {
-        my $disp = join '|', @disp;
-        $body =~ s/($disp)/$shield->($1)/egs;
-    }
+    #    cross line breaks but never a BLANK line (client MathJax cannot
+    #    typeset across a paragraph break anyway -- $nb below) and never
+    #    a shield token (\x1A) -- so an unbalanced delimiter stays
+    #    literal instead of swallowing the headings/lists/fences after
+    #    it. The asymmetric forms \(..\) and \[..\] additionally exclude
+    #    their OWN OPENER from the span content: a dangling \( / \[ then
+    #    fails at the NEXT opener (O(gap)) instead of scanning to end of
+    #    body from every opener (O(n^2) -- a stored ReDoS: 64 KB of "\("
+    #    pinned a worker for seconds per uncached view). $$ is symmetric
+    #    (openers pair with each other), so it needs no exclusion and no
+    #    length cap -- a formula of any size shields intact.
+    my $nb = qr/(?!\r?\n[ \t]*\r?\n)/;
+    $body =~ s{(
+        \$\$ (?: $nb [^\x{1A}] )+? \$\$
+      | \\\[ (?: $nb (?! \\\[ ) [^\x{1A}] )+? \\\]
+      | \\\( (?: $nb (?! \\\( ) [^\x{1A}] )+? \\\)
+    )}{$shield->($1)}egsx;
     #    Inline $..$ -> \(..\), pandoc rules: non-space inside; the
     #    opening $ not preceded by a digit (keeps postfix currency
     #    "5$짜리 ... 10$짜리" as text) and the closing $ not followed
@@ -248,11 +249,19 @@ sub _del {
 # `~~x~~` in a code span stays literal. Used by stage 7 and _span_md
 # (a cell/footnote-def may hold an inline <code> span too). A ~~ pair
 # cannot span a code region -- the split breaks it (documented limit).
+# The region body excludes further <pre/<code OPENERS so a dangling
+# (unclosed) one fails at the next opener instead of scanning to end of
+# string from every opener -- else this is the same O(n^2) stored ReDoS
+# as the math stage (a body of unclosed "<code" is plantable, since
+# escape_tags does not denylist pre/code).
 sub _del_outside_code {
     my $t = shift;
     return join '', map {
         /^<(?:pre|code)\b/i ? $_ : _del($_)
-    } split /(<pre\b.*?<\/pre>|<code\b.*?<\/code>)/si, $t;
+    } split /(
+        <pre\b  (?: (?! <pre\b ) (?! <code\b ) . )*? <\/pre>
+      | <code\b (?: (?! <code\b ) (?! <pre\b ) . )*? <\/code>
+    )/six, $t;
 }
 
 # span-level markdown for a single-line fragment (table cells,

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -341,10 +341,7 @@ sub _pipe_tables {
                 my @align = map {
                     /^:-*:$/ ? 'center' : /-:$/ ? 'right' : /^:/ ? 'left' : ''
                 } @sep;
-                my $attr = sub {
-                    my ($col) = @_;
-                    return $align[$col] ? qq{ align="$align[$col]"} : '';
-                };
+                my $attr = sub { $align[$_[0]] ? qq{ align="$align[$_[0]]"} : '' };
                 my $html = '<table><thead><tr>';
                 $html .= '<th' . $attr->($_) . '>' . _span_md($hdr[$_]) . '</th>'
                     for 0 .. $#hdr;

--- a/lib/Text/Markdown.pm
+++ b/lib/Text/Markdown.pm
@@ -369,7 +369,17 @@ sub _HashHTMLBlocks {
                         )*                  # Zero or more
                     }x;
 
-    my $empty_tag = qr{< \w+ $tag_attrs \s* />}oxms;
+    # PERF (Bawi local patch): the dead first branch (matches nothing --
+    # it requires 'x' at a position where 'x' is forbidden by (?!x)) stops
+    # perl's regex optimizer from extracting the mandatory "/>" as an
+    # unbounded "floating substring". With the bare pattern, every FAILED
+    # attempt of this 'ignore' pattern inside Text::Balanced's char-by-char
+    # scan pre-scans the whole rest of the text for "/>" -- O(n) per
+    # attempt, so O(n^2) per document when many lines start with '<' (e.g.
+    # raw <pre>/<code> blocks). The union with an empty language is a
+    # no-op: the accepted language is byte-for-byte identical (verified on
+    # an 8000+ doc corpus). Remove if this file is ever re-vendored.
+    my $empty_tag = qr{ <(?!x)x | < \w+ $tag_attrs \s* />}oxms;
     my $open_tag =  qr{< $block_tags $tag_attrs \s* >}oxms;
     my $close_tag = undef;       # let Text::Balanced handle this
     my $prefix_pattern = undef;  # Text::Balanced


### PR DESCRIPTION
## MathJax in markdown mode + GFM extensions (fences, tables, strikethrough, footnotes, task lists, blockquote nesting)

Four commits, all scoped to the `category==1` (markdown) render path. Legacy articles are untouched — the legacy branch of `format_article` has a zero-line diff.

### 1. MathJax works in markdown articles (`dcdac2e`)

Markdown-mode articles previously lost most MathJax input forms: `Text::Markdown`'s backslash-escape pass ate `\(` `\)` `\[` `\]` `\\` `\{` `\}`, and emphasis could inject `<em>` into `$$..$$` (e.g. an `_` subscript right after a closing brace). Math spans are now extracted before the parser and restored verbatim **before** `escape_tags`, so math text still passes the same tag denylist as everything else.

**Single-`$` inline math is enabled for markdown articles only**: `$\bar{Z}$` is emitted as `\(\bar{Z}\)`, which the already-loaded MathJax config (`TeX-MML-AM_CHTML`) renders inline. The global config keeps single-`$` off, so legacy posts with `$` as currency/plain text behave exactly as before — and within markdown articles, pandoc-style guards (non-space inside, closing `$` not followed by a digit, single line) keep `커피는 $5 이고 케이크는 $10` as text.

### 2. GFM extensions + `Bawi::Markdown` module (`6237be2`)

The vendored `Text::Markdown` is a faithful port of 2004 Markdown.pl and predates GFM. The pipeline (factored into `lib/Bawi/Markdown.pm`, pure Perl, no new deps, lazy-`require`d like before) adds:

1. **``` fenced code blocks** → entity-escaped `<pre><code class="language-X">`. The skin already ships prism.js/prism.css, so naming a language gets syntax highlighting. Fences are extracted *first*, so `$`, `<`, `|`, `#`, `[^..]` inside code can never be taken for math, tables, markup, or footnotes.
2. **GFM pipe tables** → `<table>` emitted as raw block HTML (`Text::Markdown` passes it through without `<p>`-wrapping). Cells get span-level markdown — bold, code, `~~del~~`, and **math render inside cells**. Alignment via `:---` / `:---:` / `---:` → `align` attributes. `\|` escapes a literal pipe in a cell.
3. **`~~strikethrough~~`** → `<del>`, applied outside `<pre>`/`<code>` regions only.

### 3. Footnotes + task lists (`95df5a7`)

- **Footnotes**: `[^id]` references become numbered `<sup>` anchor links (numbered by first reference); top-level single-line `[^id]: text` definitions render as a trailing `<div class="footnotes">` ordered list with ↩ backlinks. Definitions support span-level markdown **and math**. Unknown references stay literal; unreferenced definitions drop; refs inside fences stay literal.
- **Task lists**: `- [ ]` / `- [x]` become disabled checkboxes (GFM display semantics), bullets suppressed.

### 4. Fences and tables inside blockquotes (`8f47515`)

The fence pass captures an optional uniform `> ` prefix, strips the quote markers from code lines (up to the quote level — code lines keeping their own `>` characters survive), and re-emits the prefix around the shield token so the block stays inside the quote. The table scanner is quote-level-aware: all rows must sit at the same level, the emitted `<table>` keeps the prefix, and a level change ends the table.

**Fences/tables inside list *items* stay unsupported by design**: 4-space indentation inside a list item already means "code block" in classic markdown, so a pre-pass cannot disambiguate without real block-structure parsing. 8-space-indented code inside a list item is native classic markdown and keeps working.

### Verification

- **Smoke**: 48 assertions (9 original + 10 math + 13 GFM + 11 footnote/task + 5 blockquote-nesting), passing with host perl and in-container perl 5.34 (`perl board/script/markdown_smoke.pl`).
- **Mirror e2e** (Docker test mirror, full overlay of main + this branch, four rounds): posted a demo article exercising every feature; all served-HTML assertions pass — intact `$$..$$`/`\[..\]`/`\(..\)`, `$..$`→`\(..\)`, currency negative, fence class + entity escaping, table build/alignment/cell-markdown/`\|`, prose-with-pipes negative, `<del>` + code-region negatives, checkboxes, footnote numbering/backlinks/math-in-def, quoted fence/table inside `<blockquote>` (regex-verified containment), no `<em>` injection, no leftover shield tokens, denylist applied inside math.
- **Browser (MathJax 2.7.1 from cdnjs, prism)**: inline Z̄ and twistor norm mid-sentence; display math centered; `pmatrix`; prism tokens in top-level *and quoted* fences (11 tokens inside the quote); tables with math/bold/del/code in aligned cells, including **MathJax inside a quoted table cell**; task checkboxes; footnote superscripts + section; currency literal.
- **Legacy**: legacy read pages 200; legacy code path byte-identical.
- Mirror restored clean after each round (status empty, sanity 200s); test articles removed.

### Deploy

Code-only, no migration: `git pull` + graceful Apache restart (mod_perl caches `lib/Bawi/*.pm`).

### Known v1 ceilings (documented in the module header)

- Fences/tables work at top level **and inside blockquotes**, but **not inside list items** (native 8-space-indented code in list items works). Footnote definitions are top-level, single-line.
- A pipe-table lookalike inside a 4-space-indented code block parses as a table — use a ``` fence for code instead.
- A single `$..$` written across two table cells can eat a pipe; `$..$`/`[^ref]` inside inline backtick code spans are still transformed (``` fences are fully immune).
- The default skin has no `table` CSS for article bodies, so tables render borderless (cosmetic follow-up if wanted).

### Demo article source (paste-ready, markdown checkbox on)

The exact text posted during e2e — doubles as user-facing documentation of every supported feature:

~~~
# 마크다운 사용 예시 (제목 1)

## 제목 2

### 제목 3

문단은 빈 줄로 구분합니다. 같은 문단 안에서 그냥 줄을 바꾸면
하나의 문단으로 이어집니다.

**굵게**, *기울임*, ***굵은 기울임***, 그리고 `인라인 코드`.

## 목록

- 순서 없는 목록
- 두 번째 항목
    - 네 칸 들여쓰면 중첩 목록
- 세 번째 항목

1. 순서 있는 목록
2. 두 번째
3. 세 번째

## 링크와 이미지

[바위](http://bawi.org) 처럼 쓰거나, <http://bawi.org> 처럼 자동 링크.

![투표 아이콘](/board/skin/default/images/poll.gif) ← 이미지 삽입 문법.

## 인용

> 인용문입니다.
> 여러 줄을 이어 쓸 수 있고,
>
> > 이렇게 중첩 인용도 됩니다.

인용 안에 코드 펜스와 표도 들어갑니다:

> 인용 속 코드와 표:
>
> ```python
> def norm(z): return abs(z)**2
> ```
>
> | 항목 | 값 |
> |------|---:|
> | 노름 | $Z_\alpha \bar{Z}^\alpha$ |

## 코드 블록

코드는 네 칸 들여쓰기로 쓰거나:

    my $x = 42;
    print "hello, $x\n";
    $$코드 블록 안에서는 수식으로 바뀌지 않음$$

## 코드 펜스

백틱 세 개로 감싸도 됩니다. 언어를 적으면 색이 입혀집니다 (prism):

```perl
my $twistor = { Z => [1, 2], W => [3, 4] };
print "노름: $$twistor{Z}[0]\n";   # $ 기호도 코드 안에서는 안전
if ($x < $y) { print "부등호도 그대로\n"; }
```

## 표

| 변수 | 의미 | 정렬 예시 |
|:-----|:----:|---------:|
| $Z$ | 정칙 (holomorphic) | 왼쪽 |
| $\bar{Z}$ | **반정칙** | 오른쪽 |
| 셀 안 `코드` | ~~취소선~~ | $Z_\alpha \bar{Z}^\alpha$ |

## 취소선

~~틀린 내용은 이렇게~~ 물결 두 개로 지웁니다.

## 작업 목록

- [ ] 아직 안 한 일
- [x] 끝낸 일
- 일반 항목과 섞어도 됩니다

## 각주

트위스터 이론[^1]은 펜로즈가 제안했고, 구글리 문제[^googly]가 남아 있습니다.

[^1]: 각주 안에서 **마크다운**과 $Z_\alpha$ 수식도 됩니다.
[^googly]: 크리켓 용어에서 온 이름.

## 수식 (MathJax)

인라인 수식은 달러 하나: 반정칙 변수 $\bar{Z}$, 트위스터 노름 $Z_\alpha \bar{Z}^\alpha$ 처럼 문장 속에 들어갑니다.

디스플레이 수식은 달러 두 개:

$$Z_\alpha \bar{Z}^\alpha = 0$$

\( \bar{Z} \) 인라인 표기와 \[ E = mc^2 \] 디스플레이 표기도 그대로 동작합니다.

행렬도 됩니다 (\\ 줄바꿈 유지):

$$\begin{pmatrix} a & b \\ c & d \end{pmatrix}$$

가격 표기는 수식이 되지 않습니다: 커피는 $5 이고 케이크는 $10 입니다.

## 구분선

---

## 지원하지 않는 것 (v1)

**목록 항목 안에** 표나 코드 펜스를 넣는 것은 지원하지 않습니다 (인용 안에는 됩니다 — 위 참조). 목록 안에서 코드가 필요하면 8칸 들여쓰기를 쓰세요 (클래식 마크다운 기본 기능). 각주 정의는 문서 최상위 한 줄짜리만 됩니다. 원시 HTML은 <b>그대로</b> 통과합니다 (script/iframe 등 위험 태그만 이스케이프).
~~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)
