### PR TITLE
Fit article-body images to width; add borders to content tables

### DIFF
--- a/main/skin/default/dark_style.css
+++ b/main/skin/default/dark_style.css
@@ -13,9 +13,12 @@ body {
   color: #bbb !important;
   background-color: #222 !important;
 }
-.body.text a    { 
-  background: #333 !important; 
+.body.text a    {
+  background: #333 !important;
 }
+.body.text table:not(.wrapper) th,
+.body.text table:not(.wrapper) td { border: 1px dotted #666 !important; }
+.body.text table:not(.wrapper) th { background: #444 !important; }
 a {
   color: #bbb !important;
 }

--- a/main/skin/default/style.css
+++ b/main/skin/default/style.css
@@ -377,6 +377,14 @@ ul.bookmark li.item.head ul li a { display: inline; color: white; }
 .body.text small,
 .body.text sub,
 .body.text sup { font-size: 0.83em; }
+/* Article-body images: never overflow the column (fit to width, keep ratio). */
+.body.text img { max-width: 100%; height: auto; }
+/* Markdown/content tables get borders. Scoped :not(.wrapper) so the layout
+   table.safety.wrapper that holds the whole body is left untouched. */
+.body.text table:not(.wrapper) { border-collapse: collapse; margin: 1em 0; }
+.body.text table:not(.wrapper) th,
+.body.text table:not(.wrapper) td { border: 1px solid #ccc; padding: 4px 8px; }
+.body.text table:not(.wrapper) th { background: #f2f2f2; }
 
 
 /**********************************************************************************/


### PR DESCRIPTION
Two article-body rendering gaps surfaced while testing the markdown launch: a wide inserted image (e.g. an SVG) **overflowed the column**, and markdown/content **tables had no borders**. Both are the same root cause — the markdown feature styled `.body.text` headings/blockquotes/code but never added rules for `img` width or `table` borders.

## Fix (CSS-only — no render change)

The rendered HTML is unchanged, so **no `CACHE_VERSION` bump** and cached article HTML stays valid; a plain deploy (git pull) picks it up, no restart needed for a static CSS file.

`main/skin/default/style.css` (the effective sheet — `board/skin/default/style.css` `@import`s it), in the existing `.body.text` block:

- `.body.text img { max-width: 100%; height: auto; }` — images shrink to fit any column width, aspect preserved. Fixes **all** oversized article images, not just SVG.
- `.body.text table:not(.wrapper)` gets `border-collapse` + 1px cell borders + a shaded `th`. Scoped `:not(.wrapper)` so the layout `table.safety.wrapper` that wraps the whole body is left alone (otherwise the entire article would get boxed).

`dark_style.css`: matching dotted `#666` borders + `#444` `th` for dark mode.

## Verified on the mirror

Posted an article with the 980px bracket SVG + a markdown table and screenshotted the rendered read page: the image scales to fit the column (no overflow) and the table shows cell borders with a shaded header. DOM check confirmed the markdown `<img>` and bare `<table><thead>` land inside `li.body.text` (so the selectors match) and the layout `table.safety.wrapper` is correctly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
