### PR TITLE
Code-block styling: fit/box plain blocks, dark-mode theme, cache-bust CSS

### DIFF
--- a/board/skin/default/_html_header.tmpl
+++ b/board/skin/default/_html_header.tmpl
@@ -21,8 +21,9 @@
 
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/prototype/1.6/prototype.js"></script>
 <style>:root { color-scheme: light dark }</style>
-<link rel="stylesheet" type="text/css" href="skin/<tmpl_if skin><tmpl_var skin><tmpl_else>default</tmpl_if>/style.css" />
-<link rel="stylesheet" type="text/css" media="(prefers-color-scheme: dark)" href="skin/default/dark_style.css" />
+<!-- ?v= busts the browser CSS cache; bump the token whenever style.css / dark_style.css change -->
+<link rel="stylesheet" type="text/css" href="skin/<tmpl_if skin><tmpl_var skin><tmpl_else>default</tmpl_if>/style.css?v=20260713" />
+<link rel="stylesheet" type="text/css" media="(prefers-color-scheme: dark)" href="skin/default/dark_style.css?v=20260713" />
 <!--[if lt IE 8]>
 <link rel="stylesheet" type="text/css" href="<tmpl_var main_url>/skin/default/IE70Fixes.css" /><![endif]-->
 <!--[if lte IE 8]><style type="text/css"> #globalWrapper{font-family:"맑은 고딕",sans-serif;} </style><![endif]-->

--- a/main/skin/default/_html_header.tmpl
+++ b/main/skin/default/_html_header.tmpl
@@ -21,8 +21,9 @@
 
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/prototype/1.6/prototype.js"></script>
 <style>:root { color-scheme: light dark }</style>
-<link rel="stylesheet" type="text/css" href="skin/<tmpl_if skin><tmpl_var skin><tmpl_else>default</tmpl_if>/style.css" />
-<link rel="stylesheet" type="text/css" media="(prefers-color-scheme: dark)" href="skin/default/dark_style.css" />
+<!-- ?v= busts the browser CSS cache; bump the token whenever style.css / dark_style.css change -->
+<link rel="stylesheet" type="text/css" href="skin/<tmpl_if skin><tmpl_var skin><tmpl_else>default</tmpl_if>/style.css?v=20260713" />
+<link rel="stylesheet" type="text/css" media="(prefers-color-scheme: dark)" href="skin/default/dark_style.css?v=20260713" />
 <!--[if lt IE 8]>
 <link rel="stylesheet" type="text/css" href="<tmpl_var main_url>/skin/default/IE70Fixes.css" /><![endif]-->
 <!--[if lte IE 8]><style type="text/css"> #globalWrapper{font-family:"맑은 고딕",sans-serif;} </style><![endif]-->

--- a/main/skin/default/dark_style.css
+++ b/main/skin/default/dark_style.css
@@ -19,6 +19,25 @@ body {
 .body.text table:not(.wrapper) th,
 .body.text table:not(.wrapper) td { border: 1px dotted #666 !important; }
 .body.text table:not(.wrapper) th { background: #444 !important; }
+/* Dark-mode code: prism.css is a light theme (light box, dark tokens) -> glaring
+   and low-contrast on the dark page. Recolor the box + tokens to a light-on-dark
+   palette (prism-tomorrow) for both ```lang and plain ``` blocks. */
+.body.text pre,
+.body.text pre[class*="language-"] { background: #2d2d2d !important; color: #ccc !important; }
+.body.text pre code,
+.body.text code[class*="language-"] { color: #ccc !important; background: none !important; }
+.body.text .token.comment, .body.text .token.prolog,
+.body.text .token.doctype, .body.text .token.cdata { color: #999 !important; }
+.body.text .token.punctuation { color: #ccc !important; }
+.body.text .token.property, .body.text .token.tag, .body.text .token.boolean,
+.body.text .token.number, .body.text .token.constant, .body.text .token.symbol,
+.body.text .token.deleted { color: #e2777a !important; }
+.body.text .token.selector, .body.text .token.attr-name, .body.text .token.string,
+.body.text .token.char, .body.text .token.builtin, .body.text .token.inserted { color: #7ec699 !important; }
+.body.text .token.operator, .body.text .token.entity, .body.text .token.url { color: #67cdcc !important; }
+.body.text .token.atrule, .body.text .token.attr-value, .body.text .token.keyword { color: #cc99cd !important; }
+.body.text .token.function, .body.text .token.class-name { color: #f08d49 !important; }
+.body.text .token.regex, .body.text .token.important, .body.text .token.variable { color: #7ec699 !important; }
 a {
   color: #bbb !important;
 }

--- a/main/skin/default/style.css
+++ b/main/skin/default/style.css
@@ -385,6 +385,12 @@ ul.bookmark li.item.head ul li a { display: inline; color: white; }
 .body.text table:not(.wrapper) th,
 .body.text table:not(.wrapper) td { border: 1px solid #ccc; padding: 4px 8px; }
 .body.text table:not(.wrapper) th { background: #f2f2f2; }
+/* Plain (no-language) fenced code blocks look like the prism-highlighted
+   ones. Prism copies the language- class onto <pre> at runtime so prism.css
+   styles pre[class*=language-]; a plain ``` block's <pre> stays class-less,
+   so give it the same box here. overflow-x lets long lines scroll instead
+   of overflowing the column. */
+.body.text pre:not([class]) { background: #f5f2f0; padding: 1em; margin: 0.5em 0; overflow-x: auto; }
 
 
 /**********************************************************************************/


### PR DESCRIPTION
Two article-rendering polish items from the markdown launch. CSS/template-only — no render change, no `CACHE_VERSION` bump.

## 1. Plain code blocks now look like highlighted ones

A ```` ```lang ```` block gets its box because **Prism copies the `language-` class onto `<pre>` at runtime** and `prism.css` styles `pre[class*="language-"]`. A plain ```` ``` ```` block has no language, so Prism skips it and its `<pre>` stays class-less and unstyled. Added `.body.text pre:not([class])` with Prism's own box values (`#f5f2f0` bg, `1em` padding, `overflow-x:auto`) so plain blocks match, and long lines scroll instead of overflowing.

Verified on the mirror — an article with a perl block and a plain block: both `<pre>` compute to `rgb(245,242,240)` / 15px / `overflow-x:auto` (the perl one via Prism's `pre.language-perl`, the plain one via the new rule).

## 2. Cache-bust the CSS URLs

CSS changes weren't reaching users holding a cached `style.css` (you had to switch browsers to see PR #18). Added a `?v=` token to the `style.css` / `dark_style.css` `<link>`s in both header templates (`main/` and `board/` — board read pages use the board one). Bumping the token on any CSS change makes browsers refetch on the next page load. Static token with an inline "bump me" comment (no tparam plumbing).

Verified the board read page now emits `style.css?v=20260713` and the versioned URL serves `200`.

**Deploy:** CSS/template only → `git pull` (no restart needed; static CSS + template files). This PR's `?v=` bump also force-refetches the PR #18 fix for everyone on their next page load, so no more "switch browsers."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 3. Dark mode for code blocks (added)

`prism.css` is a light theme and `dark_style.css` had no code handling, so in dark mode code blocks were glaring light boxes with low-contrast syntax colors. Added a dark code theme in `dark_style.css`: `#2d2d2d` box + `#ccc` base text, with prism's token groups remapped to a light-on-dark (prism-tomorrow) palette. Covers both `` ```lang `` and plain `` ``` `` blocks; `!important` so it wins over `prism.css` regardless of link order. Inline `code` has no background in either mode, so it's untouched.

Verified on the mirror in forced-dark: body `#222`, both `<pre>` boxes `#2d2d2d`/`#ccc` text, keyword token `#cc99cd` — readable.
