### PR TITLE
Fit article body to the column on mobile (table-layout:fixed)

### DIFF
--- a/board/skin/default/_html_header.tmpl
+++ b/board/skin/default/_html_header.tmpl
@@ -22,8 +22,8 @@
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/prototype/1.6/prototype.js"></script>
 <style>:root { color-scheme: light dark }</style>
 <!-- ?v= busts the browser CSS cache; bump the token whenever style.css / dark_style.css change -->
-<link rel="stylesheet" type="text/css" href="skin/<tmpl_if skin><tmpl_var skin><tmpl_else>default</tmpl_if>/style.css?v=20260713" />
-<link rel="stylesheet" type="text/css" media="(prefers-color-scheme: dark)" href="skin/default/dark_style.css?v=20260713" />
+<link rel="stylesheet" type="text/css" href="skin/<tmpl_if skin><tmpl_var skin><tmpl_else>default</tmpl_if>/style.css?v=20260714" />
+<link rel="stylesheet" type="text/css" media="(prefers-color-scheme: dark)" href="skin/default/dark_style.css?v=20260714" />
 <!--[if lt IE 8]>
 <link rel="stylesheet" type="text/css" href="<tmpl_var main_url>/skin/default/IE70Fixes.css" /><![endif]-->
 <!--[if lte IE 8]><style type="text/css"> #globalWrapper{font-family:"맑은 고딕",sans-serif;} </style><![endif]-->

--- a/main/skin/default/_html_header.tmpl
+++ b/main/skin/default/_html_header.tmpl
@@ -22,8 +22,8 @@
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/prototype/1.6/prototype.js"></script>
 <style>:root { color-scheme: light dark }</style>
 <!-- ?v= busts the browser CSS cache; bump the token whenever style.css / dark_style.css change -->
-<link rel="stylesheet" type="text/css" href="skin/<tmpl_if skin><tmpl_var skin><tmpl_else>default</tmpl_if>/style.css?v=20260713" />
-<link rel="stylesheet" type="text/css" media="(prefers-color-scheme: dark)" href="skin/default/dark_style.css?v=20260713" />
+<link rel="stylesheet" type="text/css" href="skin/<tmpl_if skin><tmpl_var skin><tmpl_else>default</tmpl_if>/style.css?v=20260714" />
+<link rel="stylesheet" type="text/css" media="(prefers-color-scheme: dark)" href="skin/default/dark_style.css?v=20260714" />
 <!--[if lt IE 8]>
 <link rel="stylesheet" type="text/css" href="<tmpl_var main_url>/skin/default/IE70Fixes.css" /><![endif]-->
 <!--[if lte IE 8]><style type="text/css"> #globalWrapper{font-family:"맑은 고딕",sans-serif;} </style><![endif]-->

--- a/main/skin/default/style.css
+++ b/main/skin/default/style.css
@@ -421,7 +421,11 @@ ul.article > li.body        { float: none; clear: both; overflow: visible; width
 ul.article > li.body        { max-width: 600px; margin: 0 auto; }
 ul.article > li.body.text   { line-height: 170%; text-align: justify; padding: 20px 0 10px 0;  }
 ul.article > li.body.text   { border-bottom: 0; }
-ul.article > li.body.text table.safety.wrapper { position: relative; width: 100%; }
+/* table-layout:fixed so the body-wrapper table honors its 100% width instead of
+   auto-expanding to its widest content (code blocks, wide images) and overflowing
+   the column on mobile. Lets the .body.text img (max-width) and pre (overflow-x)
+   caps actually take effect. */
+ul.article > li.body.text table.safety.wrapper { position: relative; width: 100%; table-layout: fixed; }
 ul.article > li.attach ol   { list-style: decimal; padding: 0; overflow: hidden; }
 ul.article > li.attach li   { padding: 0; margin: 0; line-height: 170%; vertical-align: top; list-style-position: inside; }
 ul.article > li.attach a    { display: inline; }


### PR DESCRIPTION
## Problem
Announcement / markdown posts overflow horizontally on mobile. The article body sits inside `<table class="safety wrapper">`, which uses the default `table-layout: auto` and therefore sizes to its **widest content** (markdown `<pre>` code blocks, wide/SVG images) rather than to the ~365px mobile column. That defeats the existing `.body.text img { max-width:100% }` and `pre { overflow-x:auto }` caps, because an auto-layout table expands to intrinsic content width regardless of child `max-width`/`overflow`.

Confirmed on the live post `read.cgi?bid=990&aid=1797135` at a 390px iPhone viewport (with the mobile viewport meta present): the body renders **583px** inside a 365px column → **+198px** horizontal overflow. Removing the SVG doesn't help — the code blocks keep it wide.

## Fix
Add `table-layout: fixed` to the body wrapper so it honors `width:100%`; the existing `img`/`pre` caps then take effect.

Verified on the live page by injecting the rule: body **583px → 365px**, overflow **+198px → none**. Desktop layout unchanged.

Also bumps the CSS cache-bust token (`20260713 → 20260714`) so clients re-fetch the changed `style.css`.

## Investigated, not a bug
A suspected missing `<meta name="viewport">` turned out to be a red herring — it was absent only under a **desktop** User-Agent. With an iPhone UA the live page serves it correctly via `Bawi::Board::UI::is_mobile_device` UA-sniffing. No template/prod change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
