### PR TITLE
Add reproducible local Docker test environment (web+db, schema, seeder)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ admin/process/dat/*.txt
 /main/BingSiteAuth.xml
 /main/google*.html
 /maint
+.env

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -56,7 +56,7 @@ Open **http://localhost:8080/** — you'll get the login page.
 | account | password | notes |
 |---|---|---|
 | `root` | `test1234` | admin (matches the hardcoded admin list in `Bawi::Auth`) |
-| `testuser02` … `testuser50` | `test1234` | regular synthetic members |
+| `tester02` … `tester50` | `test1234` | regular synthetic members |
 
 Useful URLs once logged in:
 
@@ -95,7 +95,7 @@ Through the real stack (recommended — exercises mod_perl exactly like prod):
 curl -s http://localhost:8080/main/db-test.cgi
 
 # authenticated: log in once, keep the session cookie
-curl -s -c /tmp/bawi.jar -d 'id=testuser02&passwd=test1234' \
+curl -s -c /tmp/bawi.jar -d 'id=tester02&passwd=test1234' \
      http://localhost:8080/main/login.cgi -o /dev/null
 curl -s -b /tmp/bawi.jar http://localhost:8080/board/index.cgi
 ```
@@ -124,7 +124,8 @@ runner logs a line per file, so a migration it didn't pick up is visible in
 `docker compose logs db`.
 
 Data in migrations: transforms of existing rows are fine (reseed regenerates
-data in final shape). Reference rows prod needs may ride in the migration
+data — keep `seed.pl` emitting the post-migration shape). Reference rows prod
+needs may ride in the migration
 (idempotently) for prod's sake — `db/` is also the prod migration channel —
 but must then be **mirrored in `seed/seed.pl`**: reseed truncates every base
 table except `schema_migrations`, so migration-inserted rows silently vanish

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -79,7 +79,7 @@ docker compose restart web            # REQUIRED after editing lib/Bawi/*.pm
                                       #  picked up on the next request)
 ./seed/reseed.sh                      # wipe + reseed synthetic data
 docker compose exec web bash          # shell in the web container
-mysql -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi   # DB from host
+mysql -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi   # DB from host (your BAWI_DB_PORT if overridden)
 docker compose down                   # stop (data volumes kept)
 docker compose down -v                # stop and DESTROY db + attachment + photo volumes
 ```
@@ -118,10 +118,15 @@ dumps and are never executed) are applied on first DB init by
 `docker/db/init/20-apply-migrations.sh`. Double-apply protection is the
 `schema_migrations` tracking table: migrations already contained in the
 schema dump are pre-recorded as `baseline` by `docker/db/init/15-baseline.sql`,
-everything else runs and is recorded as `applied` (currently
-`20260708_create_career.sql` and `20260712_create_body_html.sql`). The runner
-logs a line per file, so a migration it didn't pick up is visible in
+everything else runs and is recorded as `applied` (every dated `db/` file
+newer than the dump — the runner's closing state listing shows which). The
+runner logs a line per file, so a migration it didn't pick up is visible in
 `docker compose logs db`.
+
+Migrations must be structure-only or idempotent data transforms. Reference
+rows a migration would INSERT belong in `seed/seed.pl` instead — reseed
+truncates every base table except `schema_migrations`, so migration-inserted
+rows would silently vanish on the next reseed.
 
 After adding a new `db/YYYYMMDD_*.sql` to a *running* env (from the checkout
 that launched it):
@@ -144,12 +149,12 @@ retrying — a half-initialized data dir skips init on the next start.
 ## Validation checklist (what "working" looks like)
 
 1. `docker compose ps` — the db and web containers both `Up`.
-2. `docker compose exec -T db mysql -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 lines: 1 column-header line + 61 tables (incl. `schema_migrations`) + the `freq_bookmark` view.
+2. `docker compose exec -T db mysql -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 lines: 1 column-header line + 61 tables (incl. `schema_migrations`) + the `freq_bookmark` view. (Grows by one per table-adding migration — cross-check against the runner's state listing in `docker compose logs db`.)
 3. `curl -s http://localhost:8080/main/db-test.cgi` → three `before query:/after query:/dbh->errstr:` lines then the six seeded board titles (no 500).
 4. `curl -s http://localhost:8080/` → login page HTML (200).
 5. Login POST (see above) → `302` with `Set-Cookie: bawi_session=…`.
 6. `curl -s -b /tmp/bawi.jar http://localhost:8080/board/index.cgi` → bookmark page listing seeded boards.
-7. Markdown render path: read a seeded markdown article (free board, e.g. `curl -s -b /tmp/bawi.jar 'http://localhost:8080/board/read.cgi?bid=2&aid=36'`) → body contains rendered HTML (`<h2>`, `<code>`), and `SELECT COUNT(*) FROM bw_xboard_body_html` goes from 0 to ≥1 after the read.
+7. Markdown render path: read a seeded markdown article (free board, e.g. `curl -s -b /tmp/bawi.jar 'http://localhost:8080/board/read.cgi?bid=2&aid=36'`; markdown articles are free-board nos 20-24, `aid` = 15 + article_no — recompute if `@BOARDS` changes) → body contains rendered HTML (`<h2>`, `<code>`), and `SELECT COUNT(*) FROM bw_xboard_body_html` goes from 0 to ≥1 after the read.
 8. `docker compose logs web | grep -i "error"` → no Perl compile errors.
 
 Known-broken pages (repo gap, **not** an environment fault): `board/x.cgi`,

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,132 @@
+# Installation — local Docker test environment
+
+Reproducible **local** Docker environment for the bawi BBS (Apache 2.4 +
+mod_perl2 + Perl 5.34 + MariaDB 10.6 on Ubuntu 22.04 — same stack as prod),
+with a structure-only copy of the production schema and deterministic
+**synthetic** data.
+
+> **LOCAL-ONLY, BY CONSTRUCTION.** All published ports are bound to
+> `127.0.0.1` in `docker-compose.yml` (`127.0.0.1:8080:80`,
+> `127.0.0.1:3307:3306`), so the stack is reachable **only from this
+> machine**, never the LAN/internet. Keep it that way: a bare `8080:80`
+> would publish on all interfaces. Everything in here is throwaway/fake:
+> no real credentials, no real user data.
+
+## Prerequisites
+
+Docker (Desktop) running; works with legacy `docker-compose` 1.29+ or modern
+`docker compose` — use whichever your installation has.
+
+## Run it
+
+```sh
+cd <repo>
+docker compose up -d --build    # or: docker-compose up -d --build
+```
+
+First start takes a few minutes: the web image builds, and the db container
+creates database `bawi`, loads `docker/db/init/10-schema.sql` (prod schema,
+structure only, no rows), and runs the guarded migration runner over
+`db/*.sql`. The web entrypoint materializes `conf/*.conf` (gitignored — prod
+keeps its real configs untracked there) from `docker/conf/*.conf` unless they
+already exist; delete yours to regenerate.
+
+Then load the synthetic data (idempotent — safe to re-run any time):
+
+```sh
+./seed/reseed.sh                # = docker compose exec web perl /home/bawi/bawi-spring/seed/seed.pl
+```
+
+Open **http://localhost:8080/** — you'll get the login page.
+
+| account | password | notes |
+|---|---|---|
+| `root` | `test1234` | admin (matches the hardcoded admin list in `Bawi::Auth`) |
+| `testuser02` … `testuser50` | `test1234` | regular synthetic members |
+
+Useful URLs once logged in:
+
+- `http://localhost:8080/board/index.cgi` — bookmarks / board overview
+- `http://localhost:8080/board/boards.cgi` — board list
+- `http://localhost:8080/main/news.cgi` — recent articles
+- `http://localhost:8080/main/note.cgi` — notes (10 seeded unread)
+- `http://localhost:8080/main/db-test.cgi` — plain-text DB connectivity check
+
+## Everyday commands
+
+```sh
+docker compose logs -f web            # Apache error+access log (stderr/stdout)
+docker compose restart web            # REQUIRED after editing lib/Bawi/*.pm
+                                      # (mod_perl caches modules per child;
+                                      #  .cgi edits are picked up automatically)
+./seed/reseed.sh                      # wipe + reseed synthetic data
+docker compose exec web bash          # shell in the web container
+mysql -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi   # DB from host
+docker compose down                   # stop (data volumes kept)
+docker compose down -v                # stop and DESTROY db + attachment volumes
+```
+
+The repo working tree is bind-mounted at `/home/bawi/bawi-spring` (the exact
+prod path hardcoded in `apache2/startup.pl`), so host edits are live.
+
+## Run a single .cgi
+
+Through the real stack (recommended — exercises mod_perl exactly like prod):
+
+```sh
+curl -s http://localhost:8080/main/db-test.cgi
+
+# authenticated: log in once, keep the session cookie
+curl -s -c /tmp/bawi.jar -d 'id=testuser02&passwd=test1234' \
+     http://localhost:8080/main/login.cgi -o /dev/null
+curl -s -b /tmp/bawi.jar http://localhost:8080/board/index.cgi
+```
+
+From a shell in the container (plain-CGI semantics, handy for compile checks
+and print-debugging; note mod_perl-only behaviors won't reproduce here):
+
+```sh
+docker compose exec web bash
+cd /home/bawi/bawi-spring/main
+export BAWI_PERL_HOME=/home/bawi/bawi-spring/ BAWI_DATA_HOME=/home/bawi/bawi-data/
+perl -I/home/bawi/bawi-spring/lib -c db-test.cgi        # compile check
+REQUEST_METHOD=GET QUERY_STRING='' perl -I/home/bawi/bawi-spring/lib db-test.cgi
+```
+
+## Migrations
+
+`db/2*.sql` are applied on first DB init by
+`docker/db/init/20-apply-migrations.sh`, guarded two ways (a
+`schema_migrations` tracking table + information_schema probes), so
+migrations already contained in the schema dump are recorded as `baseline`
+and never double-applied, while migrations newer than the dump (currently the
+career-v3.2 and body_html render-cache tables) are executed and recorded as
+`applied`. After adding a new `db/YYYYMMDD_*.sql` to a *running* env:
+
+```sh
+docker compose exec db bash /docker-entrypoint-initdb.d/20-apply-migrations.sh
+```
+
+To rebuild the DB from scratch: `docker compose down -v && docker compose up -d`
+then reseed.
+
+## Validation checklist (what "working" looks like)
+
+1. `docker compose ps` — `bawi-test-db` and `bawi-test-web` both `Up`.
+2. `docker compose exec db mysql -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 (62 tables incl. `schema_migrations` + header).
+3. `curl -s http://localhost:8080/main/db-test.cgi` → three `before query:/after query:/dbh->errstr:` lines then the six seeded board titles (no 500).
+4. `curl -s http://localhost:8080/` → login page HTML (200).
+5. Login POST (see above) → `302` with `Set-Cookie: bawi_session=…`.
+6. `curl -s -b /tmp/bawi.jar http://localhost:8080/board/index.cgi` → bookmark page listing seeded boards.
+7. `docker compose logs web | grep -i "error"` → no Perl compile errors.
+
+Known-broken pages (repo gap, **not** an environment fault): `board/x.cgi`,
+`main/menu.cgi`, `board/addgroup.cgi`, `board/apply.cgi`, `user/company.cgi`
+and the four `admin/*.cgi` pages 500 because their skin `*.tmpl` files were
+never committed to git (they exist only on the prod filesystem). The classic
+UI works without them.
+
+## Legacy setup
+
+The historical native-macOS (El Capitan era) instructions live on the
+`local` branch; the Docker environment above supersedes them.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -48,7 +48,7 @@ docker compose up -d --build
 Then load the synthetic data (idempotent — safe to re-run any time):
 
 ```sh
-./seed/reseed.sh                # = docker compose exec web perl /home/bawi/bawi-spring/seed/seed.pl
+./seed/reseed.sh                # = docker compose exec -T web perl /home/bawi/bawi-spring/seed/seed.pl
 ```
 
 Open **http://localhost:8080/** — you'll get the login page.
@@ -123,10 +123,12 @@ newer than the dump — the runner's closing state listing shows which). The
 runner logs a line per file, so a migration it didn't pick up is visible in
 `docker compose logs db`.
 
-Migrations must be structure-only or idempotent data transforms. Reference
-rows a migration would INSERT belong in `seed/seed.pl` instead — reseed
-truncates every base table except `schema_migrations`, so migration-inserted
-rows would silently vanish on the next reseed.
+Data in migrations: transforms of existing rows are fine (reseed regenerates
+data in final shape). Reference rows prod needs may ride in the migration
+(idempotently) for prod's sake — `db/` is also the prod migration channel —
+but must then be **mirrored in `seed/seed.pl`**: reseed truncates every base
+table except `schema_migrations`, so migration-inserted rows silently vanish
+on the next reseed here.
 
 After adding a new `db/YYYYMMDD_*.sql` to a *running* env (from the checkout
 that launched it):
@@ -149,7 +151,7 @@ retrying — a half-initialized data dir skips init on the next start.
 ## Validation checklist (what "working" looks like)
 
 1. `docker compose ps` — the db and web containers both `Up`.
-2. `docker compose exec -T db mysql -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 lines: 1 column-header line + 61 tables (incl. `schema_migrations`) + the `freq_bookmark` view. (Grows by one per table-adding migration — cross-check against the runner's state listing in `docker compose logs db`.)
+2. `docker compose exec -T db mysql -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 lines: 1 column-header line + 61 tables (incl. `schema_migrations`) + the `freq_bookmark` view. (Grows by one per table a migration adds — cross-check against the runner's state listing in `docker compose logs db`.)
 3. `curl -s http://localhost:8080/main/db-test.cgi` → three `before query:/after query:/dbh->errstr:` lines then the six seeded board titles (no 500).
 4. `curl -s http://localhost:8080/` → login page HTML (200).
 5. Login POST (see above) → `302` with `Set-Cookie: bawi_session=…`.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -30,14 +30,19 @@ contains (`docker/db/init/15-baseline.sql`), then executes the newer
 `db/YYYYMMDD_*.sql` migrations. The app's config is the tracked
 `docker/conf/*.conf`, bind-mounted read-only onto `conf/` inside the
 container (prod keeps its real configs untracked in `conf/`, which stays
-gitignored).
+gitignored). Any host-side `conf/*.conf` — including copies materialized by
+older versions of this environment — is ignored inside the container and safe
+to delete.
 
-Ports default to **8080** (web) and **3307** (db) on localhost. Each checkout
-gets its own compose project (named after its directory), so several
-worktrees can run stacks side by side — just give later ones different ports:
+Ports default to **8080** (web) and **3307** (db) on localhost. Each
+uniquely-named checkout gets its own compose project (project = directory
+basename; same-named checkouts would share one — use `docker compose -p` to
+disambiguate). To run stacks side by side, give later ones their own ports —
+persistently, via a gitignored `.env`:
 
 ```sh
-BAWI_HTTP_PORT=8081 BAWI_DB_PORT=3308 docker compose up -d --build
+printf 'BAWI_HTTP_PORT=8081\nBAWI_DB_PORT=3308\n' > .env
+docker compose up -d --build
 ```
 
 Then load the synthetic data (idempotent — safe to re-run any time):
@@ -70,13 +75,13 @@ containers per-project, i.e. per-directory.
 docker compose logs -f web            # Apache error+access log (stderr/stdout)
 docker compose restart web            # REQUIRED after editing lib/Bawi/*.pm
                                       # (mod_perl caches modules per child;
-                                      #  .cgi edits are picked up automatically)
-                                      # Also after editing docker/conf/*.conf.
+                                      #  .cgi and docker/conf/*.conf edits are
+                                      #  picked up on the next request)
 ./seed/reseed.sh                      # wipe + reseed synthetic data
 docker compose exec web bash          # shell in the web container
 mysql -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi   # DB from host
 docker compose down                   # stop (data volumes kept)
-docker compose down -v                # stop and DESTROY db + attachment volumes
+docker compose down -v                # stop and DESTROY db + attachment + photo volumes
 ```
 
 The repo working tree is bind-mounted at `/home/bawi/bawi-spring` (the exact
@@ -113,9 +118,10 @@ dumps and are never executed) are applied on first DB init by
 `docker/db/init/20-apply-migrations.sh`. Double-apply protection is the
 `schema_migrations` tracking table: migrations already contained in the
 schema dump are pre-recorded as `baseline` by `docker/db/init/15-baseline.sql`,
-everything else runs and is recorded as `applied` (currently the career-v3.2
-and body_html render-cache migrations). The runner logs a line per file, so
-a migration it didn't pick up is visible in `docker compose logs db`.
+everything else runs and is recorded as `applied` (currently
+`20260708_create_career.sql` and `20260712_create_body_html.sql`). The runner
+logs a line per file, so a migration it didn't pick up is visible in
+`docker compose logs db`.
 
 After adding a new `db/YYYYMMDD_*.sql` to a *running* env (from the checkout
 that launched it):
@@ -128,9 +134,12 @@ To rebuild the DB from scratch: `docker compose down -v && docker compose up -d`
 then reseed.
 
 **Refreshing `10-schema.sql` from prod:** update `15-baseline.sql` in the same
-commit (see the header comments in both files) — a migration the new dump
-contains but the baseline list misses would be re-executed and abort first
-boot.
+commit (see the header comments in both files). A migration the new dump
+reflects but the baseline list misses gets re-executed — non-idempotent DDL
+aborts first boot loudly, but idempotent migrations (ALTER MODIFY, data
+UPDATEs, DROP IF EXISTS+CREATE) re-run silently, so verify those rows by
+hand. If a first boot fails partway, `docker compose down -v` before
+retrying — a half-initialized data dir skips init on the next start.
 
 ## Validation checklist (what "working" looks like)
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -6,9 +6,8 @@ with a structure-only copy of the production schema and deterministic
 **synthetic** data.
 
 > **LOCAL-ONLY, BY CONSTRUCTION.** All published ports are bound to
-> `127.0.0.1` in `docker-compose.yml` (`127.0.0.1:8080:80`,
-> `127.0.0.1:3307:3306`), so the stack is reachable **only from this
-> machine**, never the LAN/internet. Keep it that way: a bare `8080:80`
+> `127.0.0.1` in `docker-compose.yml`, so the stack is reachable **only from
+> this machine**, never the LAN/internet. Keep it that way: a bare `8080:80`
 > would publish on all interfaces. Everything in here is throwaway/fake:
 > no real credentials, no real user data.
 
@@ -26,10 +25,20 @@ docker compose up -d --build    # or: docker-compose up -d --build
 
 First start takes a few minutes: the web image builds, and the db container
 creates database `bawi`, loads `docker/db/init/10-schema.sql` (prod schema,
-structure only, no rows), and runs the guarded migration runner over
-`db/*.sql`. The web entrypoint materializes `conf/*.conf` (gitignored — prod
-keeps its real configs untracked there) from `docker/conf/*.conf` unless they
-already exist; delete yours to regenerate.
+structure only, no rows), pre-records the migrations that dump already
+contains (`docker/db/init/15-baseline.sql`), then executes the newer
+`db/YYYYMMDD_*.sql` migrations. The app's config is the tracked
+`docker/conf/*.conf`, bind-mounted read-only onto `conf/` inside the
+container (prod keeps its real configs untracked in `conf/`, which stays
+gitignored).
+
+Ports default to **8080** (web) and **3307** (db) on localhost. Each checkout
+gets its own compose project (named after its directory), so several
+worktrees can run stacks side by side — just give later ones different ports:
+
+```sh
+BAWI_HTTP_PORT=8081 BAWI_DB_PORT=3308 docker compose up -d --build
+```
 
 Then load the synthetic data (idempotent — safe to re-run any time):
 
@@ -49,16 +58,20 @@ Useful URLs once logged in:
 - `http://localhost:8080/board/index.cgi` — bookmarks / board overview
 - `http://localhost:8080/board/boards.cgi` — board list
 - `http://localhost:8080/main/news.cgi` — recent articles
-- `http://localhost:8080/main/note.cgi` — notes (10 seeded unread)
+- `http://localhost:8080/main/note.cgi` — notes (40 seeded; each of the first 10 users has 1 unread)
 - `http://localhost:8080/main/db-test.cgi` — plain-text DB connectivity check
 
 ## Everyday commands
+
+Run these from the checkout that launched the stack — compose resolves
+containers per-project, i.e. per-directory.
 
 ```sh
 docker compose logs -f web            # Apache error+access log (stderr/stdout)
 docker compose restart web            # REQUIRED after editing lib/Bawi/*.pm
                                       # (mod_perl caches modules per child;
                                       #  .cgi edits are picked up automatically)
+                                      # Also after editing docker/conf/*.conf.
 ./seed/reseed.sh                      # wipe + reseed synthetic data
 docker compose exec web bash          # shell in the web container
 mysql -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi   # DB from host
@@ -95,13 +108,17 @@ REQUEST_METHOD=GET QUERY_STRING='' perl -I/home/bawi/bawi-spring/lib db-test.cgi
 
 ## Migrations
 
-`db/2*.sql` are applied on first DB init by
-`docker/db/init/20-apply-migrations.sh`, guarded two ways (a
-`schema_migrations` tracking table + information_schema probes), so
-migrations already contained in the schema dump are recorded as `baseline`
-and never double-applied, while migrations newer than the dump (currently the
-career-v3.2 and body_html render-cache tables) are executed and recorded as
-`applied`. After adding a new `db/YYYYMMDD_*.sql` to a *running* env:
+Dated migrations (`db/YYYYMMDD_*.sql`; the `bawi_*.sql` files are legacy full
+dumps and are never executed) are applied on first DB init by
+`docker/db/init/20-apply-migrations.sh`. Double-apply protection is the
+`schema_migrations` tracking table: migrations already contained in the
+schema dump are pre-recorded as `baseline` by `docker/db/init/15-baseline.sql`,
+everything else runs and is recorded as `applied` (currently the career-v3.2
+and body_html render-cache migrations). The runner logs a line per file, so
+a migration it didn't pick up is visible in `docker compose logs db`.
+
+After adding a new `db/YYYYMMDD_*.sql` to a *running* env (from the checkout
+that launched it):
 
 ```sh
 docker compose exec db bash /docker-entrypoint-initdb.d/20-apply-migrations.sh
@@ -110,21 +127,29 @@ docker compose exec db bash /docker-entrypoint-initdb.d/20-apply-migrations.sh
 To rebuild the DB from scratch: `docker compose down -v && docker compose up -d`
 then reseed.
 
+**Refreshing `10-schema.sql` from prod:** update `15-baseline.sql` in the same
+commit (see the header comments in both files) — a migration the new dump
+contains but the baseline list misses would be re-executed and abort first
+boot.
+
 ## Validation checklist (what "working" looks like)
 
-1. `docker compose ps` — `bawi-test-db` and `bawi-test-web` both `Up`.
-2. `docker compose exec db mysql -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 (62 tables incl. `schema_migrations` + header).
+1. `docker compose ps` — the db and web containers both `Up`.
+2. `docker compose exec -T db mysql -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 lines: 1 column-header line + 61 tables (incl. `schema_migrations`) + the `freq_bookmark` view.
 3. `curl -s http://localhost:8080/main/db-test.cgi` → three `before query:/after query:/dbh->errstr:` lines then the six seeded board titles (no 500).
 4. `curl -s http://localhost:8080/` → login page HTML (200).
 5. Login POST (see above) → `302` with `Set-Cookie: bawi_session=…`.
 6. `curl -s -b /tmp/bawi.jar http://localhost:8080/board/index.cgi` → bookmark page listing seeded boards.
-7. `docker compose logs web | grep -i "error"` → no Perl compile errors.
+7. Markdown render path: read a seeded markdown article (free board, e.g. `curl -s -b /tmp/bawi.jar 'http://localhost:8080/board/read.cgi?bid=2&aid=36'`) → body contains rendered HTML (`<h2>`, `<code>`), and `SELECT COUNT(*) FROM bw_xboard_body_html` goes from 0 to ≥1 after the read.
+8. `docker compose logs web | grep -i "error"` → no Perl compile errors.
 
 Known-broken pages (repo gap, **not** an environment fault): `board/x.cgi`,
-`main/menu.cgi`, `board/addgroup.cgi`, `board/apply.cgi`, `user/company.cgi`
-and the four `admin/*.cgi` pages 500 because their skin `*.tmpl` files were
-never committed to git (they exist only on the prod filesystem). The classic
-UI works without them.
+`main/menu.cgi`, `board/addgroup.cgi`, `board/apply.cgi`, and
+`user/company.cgi` 500 because their skin `*.tmpl` files were never committed
+to git. The admin pages are fine (their templates are in git);
+`admin/uphoto.cgi` 500s only until a photo exists under `/home/bawi/photo_attach`
+(provisioned as a named volume, empty on first boot). The classic UI works
+without any of them.
 
 ## Legacy setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,37 +4,46 @@
 # SECURITY / LOCAL-ONLY NETWORKING:
 #   Every published port below is explicitly bound to 127.0.0.1. This stack
 #   must only ever be reachable from this machine's localhost — never the LAN
-#   or the internet. Do NOT change "127.0.0.1:8080:80" to "8080:80" (a bare
-#   host port makes Docker publish on 0.0.0.0, i.e. all interfaces).
+#   or the internet. Do NOT change "127.0.0.1:${BAWI_HTTP_PORT:-8080}:80" to a
+#   bare "8080:80" (a bare host port makes Docker publish on 0.0.0.0, i.e.
+#   all interfaces).
 #
 # All credentials in this file are throwaway local test values (no real
-# secrets anywhere in this branch).
+# secrets anywhere). The DB coordinate tuple (bawi / bawi_test /
+# bawi-local-test-pw / host "db") is repeated, deliberately un-templated, in:
+# both service env blocks below, docker/conf/*.conf (the app reads those),
+# docker/web/entrypoint.sh defaults, and seed/seed.pl defaults — change one,
+# change all.
 #
-# Usage: see README.md.  Compatible with `docker compose` (v2) and legacy
-# `docker-compose` (1.29+); no v2-only syntax is used.
+# Compose project name comes from the checkout directory, so each worktree
+# gets its own isolated stack; override the two host ports to run several at
+# once: BAWI_HTTP_PORT=8081 BAWI_DB_PORT=3308 docker compose up -d
+#
+# Usage: see INSTALLATION.md.  Compatible with `docker compose` (v2) and
+# legacy `docker-compose` (1.29+); no v2-only syntax is used.
 # =============================================================================
 version: "3.8"
 
 services:
   db:
     image: mariadb:10.6
-    container_name: bawi-test-db
     environment:
-      MARIADB_ROOT_PASSWORD: bawi-local-root-pw
+      MARIADB_ROOT_PASSWORD: bawi-local-root-pw   # plain env form required by 20-apply-migrations.sh
       MARIADB_DATABASE: bawi            # production DB name is `bawi`
       MARIADB_USER: bawi_test
       MARIADB_PASSWORD: bawi-local-test-pw
     volumes:
       - bawi-db-data:/var/lib/mysql
-      # First-boot init: 10-schema.sql (prod schema, structure only) then
-      # 20-apply-migrations.sh (guarded db/*.sql migration runner).
+      # First-boot init, in lexicographic order: 10-schema.sql (prod schema,
+      # structure only), 15-baseline.sql (pre-records the migrations that
+      # dump already contains), 20-apply-migrations.sh (runs the rest).
       - ./docker/db/init:/docker-entrypoint-initdb.d:ro
-      # Repo migrations, read-only, for the migration runner.
+      # Repo migrations (db/2*.sql), read-only, for the migration runner.
       - ./db:/bawi-migrations:ro
     ports:
       # localhost-only, for host-side inspection (mysql client / GUI):
-      #   mysql -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi
-      - "127.0.0.1:3307:3306"
+      #   mysql -h 127.0.0.1 -P ${BAWI_DB_PORT:-3307} -u bawi_test -pbawi-local-test-pw bawi
+      - "127.0.0.1:${BAWI_DB_PORT:-3307}:3306"
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
@@ -44,12 +53,11 @@ services:
   web:
     build:
       context: docker/web
-    container_name: bawi-test-web
     depends_on:
       - db
     environment:
       # Used by the entrypoint wait-loop and seed/seed.pl (the app itself
-      # reads conf/*.conf, which point at the same DB).
+      # reads conf/*.conf — mounted below — which point at the same DB).
       BAWI_DB_HOST: db
       BAWI_DB_NAME: bawi
       BAWI_DB_USER: bawi_test
@@ -60,12 +68,20 @@ services:
       # picked up immediately (restart the web container to reset mod_perl's
       # in-process caches when editing lib/*.pm).
       - .:/home/bawi/bawi-spring
-      # BAWI_DATA_HOME (attachment uploads etc.) — kept out of the repo.
+      # Tracked local test configs, shadowing the host's conf/ inside the
+      # container (conf/*.conf is gitignored — prod keeps real configs
+      # untracked there). Nested read-only bind: always exactly the tracked
+      # files, nothing materialized, nothing to go stale.
+      - ./docker/conf:/home/bawi/bawi-spring/conf:ro
+      # BAWI_DATA_HOME (attachment uploads) and the photo dir — kept out of
+      # the repo; paths are hardcoded in startup.pl / the photo CGIs.
       - bawi-data:/home/bawi/bawi-data
+      - bawi-photos:/home/bawi/photo_attach
     ports:
-      # localhost-only: http://localhost:8080/
-      - "127.0.0.1:8080:80"
+      # localhost-only: http://localhost:${BAWI_HTTP_PORT:-8080}/
+      - "127.0.0.1:${BAWI_HTTP_PORT:-8080}:80"
 
 volumes:
   bawi-db-data:
   bawi-data:
+  bawi-photos:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+# =============================================================================
+# bawi-on-perl LOCAL test environment
+# =============================================================================
+# SECURITY / LOCAL-ONLY NETWORKING:
+#   Every published port below is explicitly bound to 127.0.0.1. This stack
+#   must only ever be reachable from this machine's localhost — never the LAN
+#   or the internet. Do NOT change "127.0.0.1:8080:80" to "8080:80" (a bare
+#   host port makes Docker publish on 0.0.0.0, i.e. all interfaces).
+#
+# All credentials in this file are throwaway local test values (no real
+# secrets anywhere in this branch).
+#
+# Usage: see README.md.  Compatible with `docker compose` (v2) and legacy
+# `docker-compose` (1.29+); no v2-only syntax is used.
+# =============================================================================
+version: "3.8"
+
+services:
+  db:
+    image: mariadb:10.6
+    container_name: bawi-test-db
+    environment:
+      MARIADB_ROOT_PASSWORD: bawi-local-root-pw
+      MARIADB_DATABASE: bawi            # production DB name is `bawi`
+      MARIADB_USER: bawi_test
+      MARIADB_PASSWORD: bawi-local-test-pw
+    volumes:
+      - bawi-db-data:/var/lib/mysql
+      # First-boot init: 10-schema.sql (prod schema, structure only) then
+      # 20-apply-migrations.sh (guarded db/*.sql migration runner).
+      - ./docker/db/init:/docker-entrypoint-initdb.d:ro
+      # Repo migrations, read-only, for the migration runner.
+      - ./db:/bawi-migrations:ro
+    ports:
+      # localhost-only, for host-side inspection (mysql client / GUI):
+      #   mysql -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi
+      - "127.0.0.1:3307:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+
+  web:
+    build:
+      context: docker/web
+    container_name: bawi-test-web
+    depends_on:
+      - db
+    environment:
+      # Used by the entrypoint wait-loop and seed/seed.pl (the app itself
+      # reads conf/*.conf, which point at the same DB).
+      BAWI_DB_HOST: db
+      BAWI_DB_NAME: bawi
+      BAWI_DB_USER: bawi_test
+      BAWI_DB_PASS: bawi-local-test-pw
+    volumes:
+      # Live-mount the working tree at the exact prod path so that
+      # apache2/startup.pl and all code run UNCHANGED. Edits on the host are
+      # picked up immediately (restart the web container to reset mod_perl's
+      # in-process caches when editing lib/*.pm).
+      - .:/home/bawi/bawi-spring
+      # BAWI_DATA_HOME (attachment uploads etc.) — kept out of the repo.
+      - bawi-data:/home/bawi/bawi-data
+    ports:
+      # localhost-only: http://localhost:8080/
+      - "127.0.0.1:8080:80"
+
+volumes:
+  bawi-db-data:
+  bawi-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,13 @@
 # docker/web/entrypoint.sh defaults, and seed/seed.pl defaults — change one,
 # change all.
 #
-# Compose project name comes from the checkout directory, so each worktree
-# gets its own isolated stack; override the two host ports to run several at
-# once: BAWI_HTTP_PORT=8081 BAWI_DB_PORT=3308 docker compose up -d
+# Compose project name comes from the checkout directory BASENAME, so each
+# uniquely-named worktree gets its own isolated stack (two checkouts with the
+# same basename would share one — disambiguate with `docker compose -p`).
+# Override the two host ports to run several stacks at once, persistently via
+# a gitignored .env file: printf 'BAWI_HTTP_PORT=8081\nBAWI_DB_PORT=3308\n' > .env
+# (a one-off env prefix works too, but is forgotten by the next bare
+# `docker compose up`, which then collides with the default-port stack).
 #
 # Usage: see INSTALLATION.md.  Compatible with `docker compose` (v2) and
 # legacy `docker-compose` (1.29+); no v2-only syntax is used.
@@ -38,7 +42,8 @@ services:
       # structure only), 15-baseline.sql (pre-records the migrations that
       # dump already contains), 20-apply-migrations.sh (runs the rest).
       - ./docker/db/init:/docker-entrypoint-initdb.d:ro
-      # Repo migrations (db/2*.sql), read-only, for the migration runner.
+      # Repo migrations (db/YYYYMMDD_*.sql; other names are skipped loudly),
+      # read-only, for the migration runner.
       - ./db:/bawi-migrations:ro
     ports:
       # localhost-only, for host-side inspection (mysql client / GUI):

--- a/docker/conf/board.conf
+++ b/docker/conf/board.conf
@@ -1,0 +1,54 @@
+# ##############################################################################
+# BawiX Configuration — LOCAL DOCKER TEST ENVIRONMENT (generated from
+# board.conf.sample). Credentials below are throwaway local test
+# values that only exist inside the docker-compose network. NOT for prod.
+#
+# DBName is a DBD::mysql attribute string: DB `bawi` on compose service `db`.
+DBName              database=bawi;host=db
+DBUser              bawi_test
+DBPasswd            bawi-local-test-pw
+
+# Cookie
+SessionName         bawi_session
+# SessionDomain intentionally unset -> host-only cookie, works on localhost:8080
+#SessionDomain
+LoginSuccess        ../main/index.cgi
+LoginURL            ../main/login.cgi
+PasswdURL           ../user/passwd.cgi
+LogoutURL           ../main/login.cgi
+# 0 = never force the password-change flow in the test env (sample: 90)
+PasswdExpire        0
+KeepLogin           0
+
+# Registration
+SelfRegistration    0
+
+# Skin
+DefaultSkin         default
+
+# Attachment upload directory (DO NOT include '/' at the end.)
+AttachDir           /home/bawi/bawi-data/attach
+
+# Character set
+CharSet             utf-8
+
+# Authorization
+AllowAddBoard       1
+AllowUserList       0
+AllowRecomUserList  1
+AllowRecomComment   0
+AllowAccessControl  0
+AllowAnonAccess     1
+AllowAnonBoard      0
+AllowAttach         1
+
+# HTML Title
+HTMLTitle           Bawi (LOCAL TEST)
+
+GoogleAnalytics     0
+BackgroundImageURL  ../main/image/index.gif
+NewsURL             ../main/news.cgi
+NoteURL             ../main/note.cgi
+MainURL             ../main
+BoardURL            ../board
+UserURL             ../user

--- a/docker/conf/main.conf
+++ b/docker/conf/main.conf
@@ -1,0 +1,45 @@
+# ##############################################################################
+# BawiX Configuration — LOCAL DOCKER TEST ENVIRONMENT (generated from
+# main.conf.sample). Credentials below are throwaway local test
+# values that only exist inside the docker-compose network. NOT for prod.
+#
+# DBName is a DBD::mysql attribute string: DB `bawi` on compose service `db`.
+DBName              database=bawi;host=db
+DBUser              bawi_test
+DBPasswd            bawi-local-test-pw
+
+# Cookie
+SessionName         bawi_session
+# SessionDomain intentionally unset -> host-only cookie, works on localhost:8080
+#SessionDomain
+LoginSuccess        ../main/index.cgi
+LoginURL            ../main/login.cgi
+PasswdURL           ../user/passwd.cgi
+LogoutURL           ../main/login.cgi
+# 0 = never force the password-change flow in the test env (sample: 90)
+PasswdExpire        0
+KeepLogin           0
+
+# Registration
+SelfRegistration    0
+
+# Skin
+DefaultSkin         default
+
+# Attachment upload directory (DO NOT include '/' at the end.)
+AttachDir           /home/bawi/bawi-data/attach
+
+# Character set
+CharSet             utf-8
+
+# HTML Title
+HTMLTitle           Bawi (LOCAL TEST)
+
+# Bawi::Main specific
+GoogleAnalytics     0
+BackgroundImageURL  ../main/image/index.gif
+NewsURL             ../main/news.cgi
+NoteURL             ../main/note.cgi
+MainURL             ../main
+BoardURL            ../board
+UserURL             ../user

--- a/docker/conf/user.conf
+++ b/docker/conf/user.conf
@@ -1,0 +1,57 @@
+# ##############################################################################
+# BawiX Configuration — LOCAL DOCKER TEST ENVIRONMENT (generated from
+# user.conf.sample). Credentials below are throwaway local test
+# values that only exist inside the docker-compose network. NOT for prod.
+#
+# DBName is a DBD::mysql attribute string: DB `bawi` on compose service `db`.
+DBName              database=bawi;host=db
+DBUser              bawi_test
+DBPasswd            bawi-local-test-pw
+
+# Cookie
+SessionName         bawi_session
+# SessionDomain intentionally unset -> host-only cookie, works on localhost:8080
+#SessionDomain
+LoginSuccess        ../main/index.cgi
+LoginURL            ../main/login.cgi
+PasswdURL           ../user/passwd.cgi
+LogoutURL           ../main/login.cgi
+# 0 = never force the password-change flow in the test env (sample: 90)
+PasswdExpire        0
+KeepLogin           0
+
+# Registration
+SelfRegistration    0
+
+# Skin
+DefaultSkin         default
+
+# Attachment upload directory (DO NOT include '/' at the end.)
+AttachDir           /home/bawi/bawi-data/attach
+
+# Character set
+CharSet             utf-8
+
+# Authorization
+AllowAddBoard       1
+AllowUserList       0
+AllowRecomUserList  1
+AllowRecomComment   0
+AllowAccessControl  0
+AllowAnonAccess     1
+AllowAnonBoard      0
+AllowAttach         1
+
+# HTML Title
+HTMLTitle           Bawi (LOCAL TEST)
+
+GoogleAnalytics     0
+BackgroundImageURL  ../main/image/index.gif
+NoteCheckURL        ../main/note_check.cgi
+MenuURL             ../main/menu.cgi
+NewsURL             ../main/news.cgi
+LoginURL            ../main/login.cgi
+NoteURL             ../main/note.cgi
+UserURL             ../user
+BoardURL            ../board
+MainURL             ../main

--- a/docker/db/init/10-schema.sql
+++ b/docker/db/init/10-schema.sql
@@ -9,7 +9,8 @@
 --              15-baseline.sql, which records exactly that set.
 -- WHEN REFRESHING THIS FILE from prod: strip the DEFINER clause again and
 -- update 15-baseline.sql to list every dated migration the new dump
--- includes, or first-boot init will re-execute them and abort.
+-- reflects — a missed entry is re-executed (non-idempotent DDL aborts
+-- first boot; idempotent migrations re-run silently — verify by hand).
 -- ===========================================================================
 /*M!999999\- enable the sandbox mode */
 

--- a/docker/db/init/10-schema.sql
+++ b/docker/db/init/10-schema.sql
@@ -1,4 +1,17 @@
-/*M!999999\- enable the sandbox mode */ 
+-- ===========================================================================
+-- Production schema snapshot, STRUCTURE ONLY (zero rows).
+--   source:    prod `bawi` database, dumped 2026-07-06
+--   command:   mysqldump --no-data --skip-dump-date bawi  (host/date header
+--              lines stripped; the freq_bookmark view's prod DEFINER clause
+--              removed so the view is SELECTable in the test DB, which has
+--              no `bawi`@`localhost` user)
+--   contains:  all migrations up to and including 20221221 — see
+--              15-baseline.sql, which records exactly that set.
+-- WHEN REFRESHING THIS FILE from prod: strip the DEFINER clause again and
+-- update 15-baseline.sql to list every dated migration the new dump
+-- includes, or first-boot init will re-execute them and abort.
+-- ===========================================================================
+/*M!999999\- enable the sandbox mode */
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -868,7 +881,6 @@ CREATE TABLE `schools` (
 /*!50001 SET character_set_results     = utf8mb3 */;
 /*!50001 SET collation_connection      = utf8mb3_general_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`bawi`@`localhost` SQL SECURITY DEFINER */
 /*!50001 VIEW `freq_bookmark` AS select count(0) AS `count`,`bw_xboard_bookmark`.`uid` AS `uid` from `bw_xboard_bookmark` group by `bw_xboard_bookmark`.`uid` order by count(0) desc */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;

--- a/docker/db/init/10-schema.sql
+++ b/docker/db/init/10-schema.sql
@@ -1,0 +1,885 @@
+/*M!999999\- enable the sandbox mode */ 
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `bawi_access_stat`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bawi_access_stat` (
+  `date` date NOT NULL DEFAULT '1001-01-01',
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `access` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  UNIQUE KEY `date` (`date`,`uid`),
+  KEY `uid` (`uid`,`date`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_data_major`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_data_major` (
+  `major_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `parent_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `major` varchar(32) NOT NULL DEFAULT '',
+  PRIMARY KEY (`major_id`),
+  KEY `parent_id` (`parent_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=71 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_group`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_group` (
+  `gid` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `pgid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `title` varchar(32) NOT NULL DEFAULT '',
+  `keyword` varchar(16) NOT NULL DEFAULT '',
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `type` enum('open','review','closed') NOT NULL DEFAULT 'open',
+  `seq` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `g_sub` tinyint(1) NOT NULL DEFAULT 0,
+  `m_sub` tinyint(1) NOT NULL DEFAULT 0,
+  `a_sub` tinyint(1) NOT NULL DEFAULT 0,
+  `g_board` tinyint(1) NOT NULL DEFAULT 0,
+  `m_board` tinyint(1) NOT NULL DEFAULT 0,
+  `a_board` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`gid`,`uid`),
+  UNIQUE KEY `keyword` (`keyword`),
+  KEY `pgid` (`pgid`),
+  KEY `uid` (`uid`)
+) ENGINE=MyISAM AUTO_INCREMENT=149 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_group_user`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_group_user` (
+  `gid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `status` enum('active','inactive') NOT NULL DEFAULT 'active',
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  PRIMARY KEY (`gid`,`uid`),
+  UNIQUE KEY `user` (`uid`,`gid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_note`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_note` (
+  `msg_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `to_id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  `to_name` varchar(16) NOT NULL DEFAULT '',
+  `from_id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  `from_name` varchar(16) NOT NULL DEFAULT '',
+  `msg` mediumtext NOT NULL,
+  `sent_time` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `read_time` datetime DEFAULT NULL,
+  PRIMARY KEY (`msg_id`,`to_id`),
+  UNIQUE KEY `msg_id` (`msg_id`),
+  KEY `to_id` (`to_id`,`sent_time`,`read_time`) USING BTREE,
+  KEY `from_id` (`from_id`,`sent_time`,`read_time`) USING BTREE
+) ENGINE=MyISAM AUTO_INCREMENT=1540012 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_note_notify_boxcar`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_note_notify_boxcar` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `email` varchar(64) NOT NULL DEFAULT '',
+  UNIQUE KEY `uid` (`uid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_poll`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_poll` (
+  `poll_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `gid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `title` varchar(64) NOT NULL DEFAULT '',
+  `id` varchar(10) NOT NULL DEFAULT '',
+  `name` varchar(10) NOT NULL DEFAULT '',
+  `date_s` datetime NOT NULL DEFAULT '1985-03-31 00:00:00',
+  `date_e` datetime NOT NULL DEFAULT '1986-04-28 00:00:00',
+  `secret` enum('locked','not') NOT NULL DEFAULT 'not',
+  `activated` enum('activated','not') NOT NULL DEFAULT 'not',
+  `ref_url` varchar(100) NOT NULL DEFAULT '',
+  `desc` text NOT NULL,
+  PRIMARY KEY (`poll_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_poll_check`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_poll_check` (
+  `poll_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`poll_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_poll_choice`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_poll_choice` (
+  `choice_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `question_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `choice_txt` char(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`choice_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_poll_comment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_poll_comment` (
+  `comment_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `poll_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `comment_txt` text DEFAULT NULL,
+  `comment_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY (`comment_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_poll_question`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_poll_question` (
+  `question_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `poll_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `type` enum('multiple','yesno','scale','free') NOT NULL DEFAULT 'free',
+  `question_txt` char(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`question_id`),
+  KEY `poll_id` (`poll_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_postman_log`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_postman_log` (
+  `postman_id` int(7) NOT NULL AUTO_INCREMENT,
+  `sender_name` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `sender_email` varchar(64) NOT NULL DEFAULT '',
+  `sender_ip` varchar(15) NOT NULL DEFAULT '',
+  `sender_org` varchar(255) DEFAULT NULL,
+  `bawi_uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `submit_time` datetime DEFAULT NULL,
+  PRIMARY KEY (`postman_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=117 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_symp`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_symp` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `school` varchar(255) NOT NULL DEFAULT '',
+  `department` varchar(255) NOT NULL DEFAULT '',
+  `field` varchar(255) NOT NULL DEFAULT '',
+  `education` text NOT NULL,
+  `title` text NOT NULL,
+  `abstract` text NOT NULL,
+  `reference` text NOT NULL,
+  `count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `modified` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`uid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_access`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_access` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `id` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `last_access` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `count` int(11) DEFAULT NULL,
+  PRIMARY KEY (`uid`),
+  KEY `time_index` (`last_access`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_access_history`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_access_history` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `last_access` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `id` varchar(10) DEFAULT NULL,
+  `count` int(11) DEFAULT NULL,
+  PRIMARY KEY (`uid`,`last_access`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_basic`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_basic` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `ename` varchar(96) NOT NULL DEFAULT ' ',
+  `homepage` varchar(192) NOT NULL DEFAULT '',
+  `im_msn` varchar(192) NOT NULL DEFAULT '',
+  `im_yahoo` varchar(192) NOT NULL DEFAULT '',
+  `im_nate` varchar(192) NOT NULL DEFAULT '',
+  `im_google` varchar(192) NOT NULL DEFAULT '',
+  `mobile_tel` varchar(96) NOT NULL DEFAULT '0',
+  `birth` date NOT NULL DEFAULT '1001-01-01',
+  `death` date NOT NULL DEFAULT '1001-01-01',
+  `wedding` date NOT NULL DEFAULT '1001-01-01',
+  `home_address` text DEFAULT NULL,
+  `home_map` text DEFAULT NULL,
+  `home_tel` varchar(96) NOT NULL DEFAULT '',
+  `affiliation` varchar(384) DEFAULT NULL,
+  `title` varchar(192) NOT NULL DEFAULT '',
+  `office_address` text DEFAULT NULL,
+  `office_map` text DEFAULT NULL,
+  `office_tel` varchar(96) NOT NULL DEFAULT '',
+  `temp_address` text DEFAULT NULL,
+  `temp_map` text DEFAULT NULL,
+  `temp_tel` varchar(96) NOT NULL DEFAULT '',
+  `greeting` varchar(765) NOT NULL DEFAULT '',
+  `class1` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `class2` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `class3` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `count` int(10) unsigned NOT NULL DEFAULT 0,
+  `count_today` int(10) unsigned NOT NULL DEFAULT 0,
+  `modified` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `twitter` varchar(16) DEFAULT NULL,
+  `facebook` varchar(192) DEFAULT NULL,
+  `orcid` varchar(192) DEFAULT NULL,
+  `gscholar` varchar(192) DEFAULT NULL,
+  `linkedin` varchar(192) DEFAULT NULL,
+  UNIQUE KEY `uid` (`uid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_circle`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_circle` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `circle_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`circle_id`,`uid`),
+  UNIQUE KEY `uid` (`uid`,`circle_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_degree`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_degree` (
+  `degree_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `type` enum('Bachelor','Master','Doctor','Postdoc','Resident','Fellow') NOT NULL DEFAULT 'Bachelor',
+  `school_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `department` varchar(255) NOT NULL DEFAULT '',
+  `advisors` varchar(255) NOT NULL DEFAULT '',
+  `content` text NOT NULL,
+  `start_date` date NOT NULL DEFAULT '1001-01-01',
+  `end_date` date NOT NULL DEFAULT '1001-01-01',
+  `status` varchar(20) NOT NULL,
+  PRIMARY KEY (`degree_id`),
+  KEY `uid` (`uid`),
+  KEY `school_id` (`school_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=7537 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_gbook`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_gbook` (
+  `gbook_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `guest_uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `body` text NOT NULL,
+  `reply` text NOT NULL,
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  PRIMARY KEY (`gbook_id`),
+  KEY `uid` (`uid`),
+  KEY `guest_uid` (`guest_uid`),
+  KEY `created` (`created`)
+) ENGINE=MyISAM AUTO_INCREMENT=323176 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_ki`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_ki` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `ki` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`uid`),
+  KEY `ki` (`ki`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_major`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_major` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `major_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`major_id`,`uid`),
+  KEY `uid` (`uid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_photo`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_photo` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `photo` blob NOT NULL,
+  `thumb` blob NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`uid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_sig`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_sig` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `sig` text NOT NULL,
+  PRIMARY KEY (`uid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_user_support`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_user_support` (
+  `ipgumdt` date NOT NULL DEFAULT '1001-01-01',
+  `email` varchar(50) DEFAULT NULL,
+  `name` varchar(20) DEFAULT NULL,
+  `amount` int(11) DEFAULT NULL,
+  `fee` int(11) DEFAULT NULL,
+  `realamount` int(11) DEFAULT NULL,
+  `status` varchar(20) DEFAULT NULL,
+  `paymenttype` varchar(20) DEFAULT NULL,
+  `bawiid` varchar(12) NOT NULL DEFAULT '',
+  PRIMARY KEY (`bawiid`,`ipgumdt`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xauth_new_passwd`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xauth_new_passwd` (
+  `no` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `id` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `name` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `passwd` varchar(13) NOT NULL DEFAULT '',
+  `email` varchar(64) NOT NULL DEFAULT '',
+  `birth` date NOT NULL DEFAULT '1001-01-01',
+  `ki` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `affiliation` varchar(64) NOT NULL DEFAULT '',
+  `recom_id` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `recom_passwd` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `status` enum('applied','recommended','rejected','ignored','done') NOT NULL DEFAULT 'applied',
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `pin` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`no`),
+  UNIQUE KEY `id` (`id`)
+) ENGINE=MyISAM AUTO_INCREMENT=3113 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xauth_passwd`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xauth_passwd` (
+  `uid` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `id` char(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `name` char(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `passwd` char(13) NOT NULL DEFAULT '',
+  `email` char(64) NOT NULL DEFAULT '',
+  `modified` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `accessed` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `access` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`uid`),
+  UNIQUE KEY `id` (`id`),
+  KEY `accessed` (`accessed`)
+) ENGINE=MyISAM AUTO_INCREMENT=18760 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xauth_session`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xauth_session` (
+  `session_key` char(32) NOT NULL DEFAULT '',
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `id` char(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `name` char(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `ip_address` varchar(16) DEFAULT NULL,
+  `location` varchar(256) DEFAULT NULL,
+  `user_agent` varchar(512) DEFAULT NULL,
+  PRIMARY KEY (`session_key`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_attach`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_attach` (
+  `attach_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `filename` varchar(255) NOT NULL DEFAULT '',
+  `filesize` int(10) unsigned NOT NULL DEFAULT 0,
+  `content_type` varchar(255) NOT NULL DEFAULT 'application/octet-stream',
+  `is_img` enum('y','n') NOT NULL DEFAULT 'n',
+  `width` smallint(6) NOT NULL DEFAULT 0,
+  `height` smallint(6) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`attach_id`),
+  KEY `board_id` (`board_id`,`article_id`),
+  KEY `article_id` (`article_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=305571 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_board`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_board` (
+  `board_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `keyword` varchar(16) NOT NULL DEFAULT '',
+  `gid` mediumint(8) unsigned NOT NULL DEFAULT 1,
+  `title` varchar(32) NOT NULL DEFAULT '',
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `id` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `name` varchar(10) NOT NULL DEFAULT '',
+  `skin` varchar(16) NOT NULL DEFAULT 'default',
+  `article_per_page` tinyint(3) unsigned NOT NULL DEFAULT 15,
+  `page_per_page` tinyint(3) unsigned NOT NULL DEFAULT 10,
+  `sort_list` enum('thread','number') NOT NULL DEFAULT 'thread',
+  `title_length` tinyint(3) unsigned NOT NULL DEFAULT 50,
+  `attach_limit` int(10) unsigned NOT NULL DEFAULT 307200,
+  `image_width` smallint(5) unsigned NOT NULL DEFAULT 600,
+  `thumb_width` tinyint(3) unsigned NOT NULL DEFAULT 100,
+  `thread_spacer` varchar(255) NOT NULL DEFAULT '&nbsp;&nbsp;&nbsp;',
+  `allow_attach` tinyint(1) NOT NULL DEFAULT 1,
+  `allow_recom` tinyint(1) NOT NULL DEFAULT 1,
+  `allow_scrap` tinyint(1) NOT NULL DEFAULT 1,
+  `allow_html` tinyint(1) NOT NULL DEFAULT 1,
+  `allow_category` tinyint(1) NOT NULL DEFAULT 1,
+  `escaped_tags` varchar(255) NOT NULL DEFAULT 'html body embed iframe applet script bgsound object meta',
+  `is_imgboard` tinyint(1) NOT NULL DEFAULT 0,
+  `is_anonboard` tinyint(1) NOT NULL DEFAULT 0,
+  `seq` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `articles` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `images` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `max_article_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `max_comment_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `g_read` tinyint(1) NOT NULL DEFAULT 1,
+  `m_read` tinyint(1) NOT NULL DEFAULT 1,
+  `a_read` tinyint(1) NOT NULL DEFAULT 0,
+  `g_write` tinyint(1) NOT NULL DEFAULT 1,
+  `m_write` tinyint(1) NOT NULL DEFAULT 1,
+  `a_write` tinyint(1) NOT NULL DEFAULT 0,
+  `g_comment` tinyint(1) NOT NULL DEFAULT 1,
+  `m_comment` tinyint(1) NOT NULL DEFAULT 1,
+  `a_comment` tinyint(1) NOT NULL DEFAULT 0,
+  `g_tag` tinyint(1) NOT NULL DEFAULT 1,
+  `m_tag` tinyint(1) NOT NULL DEFAULT 1,
+  `a_tag` tinyint(1) NOT NULL DEFAULT 0,
+  `expire_days` smallint(5) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`board_id`),
+  UNIQUE KEY `keyword` (`keyword`)
+) ENGINE=MyISAM AUTO_INCREMENT=3696 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_body`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_body` (
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `body` mediumtext DEFAULT NULL,
+  `modified` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`article_id`),
+  UNIQUE KEY `board` (`board_id`,`article_id`),
+  FULLTEXT KEY `body` (`body`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_bookmark`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_bookmark` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `article_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `comment_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `seq` smallint(5) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`uid`,`board_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_comment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_comment` (
+  `comment_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `comment_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `body` text DEFAULT NULL,
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `id` varchar(10) NOT NULL DEFAULT '',
+  `name` varchar(10) NOT NULL DEFAULT '',
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  PRIMARY KEY (`comment_id`),
+  UNIQUE KEY `bookmark` (`board_id`,`comment_no`),
+  KEY `article_id` (`article_id`),
+  KEY `board` (`board_id`,`article_id`),
+  KEY `uid` (`uid`)
+) ENGINE=MyISAM AUTO_INCREMENT=6044521 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_commentref`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_commentref` (
+  `commentref_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `comment_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `comment_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `ref_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `ref_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`commentref_id`),
+  UNIQUE KEY `bookmark` (`board_id`,`comment_id`,`ref_id`),
+  KEY `article_id` (`article_id`),
+  KEY `board` (`board_id`,`article_id`),
+  KEY `lookup` (`board_id`,`comment_no`),
+  KEY `lookup2` (`board_id`,`ref_no`)
+) ENGINE=MyISAM AUTO_INCREMENT=5245311 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_header`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_header` (
+  `article_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `article_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `parent_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `thread_no` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `category` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `title` char(64) NOT NULL DEFAULT '',
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `id` char(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `name` char(10) NOT NULL DEFAULT '',
+  `count` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `recom` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `scrap` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `comments` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `has_attach` tinyint(1) NOT NULL DEFAULT 0,
+  `has_poll` tinyint(1) NOT NULL DEFAULT 0,
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  PRIMARY KEY (`article_id`),
+  UNIQUE KEY `article_no` (`board_id`,`article_no`) USING BTREE,
+  KEY `board_id` (`board_id`) USING HASH,
+  KEY `thread_no` (`board_id`,`thread_no`) USING BTREE,
+  KEY `created` (`created`) USING BTREE,
+  KEY `uid` (`uid`),
+  FULLTEXT KEY `title` (`title`)
+) ENGINE=MyISAM AUTO_INCREMENT=1797043 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_notice`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_notice` (
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`board_id`,`article_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_poll`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_poll` (
+  `poll_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll` text NOT NULL,
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `closed` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  PRIMARY KEY (`poll_id`),
+  KEY `board_id` (`board_id`,`article_id`),
+  KEY `article_id` (`article_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=9904 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_poll_ans`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_poll_ans` (
+  `poll_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `opt_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`poll_id`,`uid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_poll_opt`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_poll_opt` (
+  `opt_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `poll_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `opt` text NOT NULL,
+  `count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`opt_id`),
+  KEY `poll_id` (`poll_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=47294 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_recom`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_recom` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rectime` datetime DEFAULT NULL,
+  `retracttime` datetime DEFAULT NULL,
+  PRIMARY KEY (`article_id`,`uid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_scrap`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_scrap` (
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `last_comment_no` mediumint(8) unsigned DEFAULT NULL,
+  `scrapped` datetime DEFAULT NULL,
+  PRIMARY KEY (`uid`,`article_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_stat_article`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_stat_article` (
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `title` char(64) NOT NULL DEFAULT '',
+  `id` char(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `name` char(10) NOT NULL DEFAULT '',
+  `count` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `recom` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `comments` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `ki` smallint(5) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`article_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_stat_board`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_stat_board` (
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `counts` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `articles` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `comments` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `recoms` smallint(5) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`board_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_stat_user`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_stat_user` (
+  `id` char(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `name` char(10) NOT NULL DEFAULT '',
+  `articles` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `counts` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `comments` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `recoms` smallint(5) unsigned NOT NULL DEFAULT 0,
+  KEY `user_id` (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_tag`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_tag` (
+  `tag_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `tag` varchar(255) NOT NULL DEFAULT '',
+  `count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`tag_id`),
+  UNIQUE KEY `tag` (`tag`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xboard_tagmap`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xboard_tagmap` (
+  `tagmap_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `board_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `article_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `uid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `tag_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `created` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  PRIMARY KEY (`tagmap_id`),
+  UNIQUE KEY `tagmap` (`board_id`,`article_id`,`uid`,`tag_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xpoll`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xpoll` (
+  `poll_id` int(11) NOT NULL AUTO_INCREMENT,
+  `uid` varchar(11) NOT NULL DEFAULT '',
+  `name` varchar(11) NOT NULL DEFAULT '',
+  `dt_start` date NOT NULL DEFAULT '1001-01-01',
+  `dt_end` date NOT NULL DEFAULT '1001-01-01',
+  `opt_hide` smallint(6) NOT NULL DEFAULT 0,
+  `numofq` smallint(6) NOT NULL DEFAULT 0,
+  `poll_title` varchar(100) NOT NULL DEFAULT '',
+  `poll_txt` text NOT NULL,
+  `lk` smallint(6) NOT NULL DEFAULT 0,
+  `participant` int(11) NOT NULL DEFAULT 0,
+  `id` varchar(11) NOT NULL DEFAULT '',
+  `poll_comment` text NOT NULL,
+  PRIMARY KEY (`poll_id`),
+  UNIQUE KEY `poll_title` (`poll_title`),
+  UNIQUE KEY `xpoll` (`poll_title`),
+  KEY `poll_id` (`poll_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=76 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xpoll_check`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xpoll_check` (
+  `poll_id` int(11) NOT NULL DEFAULT 0,
+  `uid` int(11) NOT NULL DEFAULT 0
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xpoll_choice`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xpoll_choice` (
+  `choice_id` int(11) NOT NULL AUTO_INCREMENT,
+  `question_id` int(11) NOT NULL DEFAULT 0,
+  `choice_txt` varchar(100) NOT NULL DEFAULT '',
+  `choice_count` int(11) NOT NULL DEFAULT 0,
+  `choice_q` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`choice_id`),
+  KEY `choice_id` (`choice_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=411 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bw_xpoll_question`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `bw_xpoll_question` (
+  `question_id` int(11) NOT NULL AUTO_INCREMENT,
+  `question_txt` varchar(100) NOT NULL DEFAULT '',
+  `poll_id` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`question_id`),
+  KEY `quetion_id` (`question_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=1402 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `circles`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `circles` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(32) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM AUTO_INCREMENT=75 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `countries`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `countries` (
+  `id` int(10) unsigned NOT NULL DEFAULT 0,
+  `name` varchar(64) NOT NULL DEFAULT '',
+  `code` varchar(2) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`),
+  UNIQUE KEY `code` (`code`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `freq_bookmark`;
+/*!50001 DROP VIEW IF EXISTS `freq_bookmark`*/;
+SET @saved_cs_client     = @@character_set_client;
+SET character_set_client = utf8mb4;
+/*!50001 CREATE VIEW `freq_bookmark` AS SELECT
+ 1 AS `count`,
+  1 AS `uid` */;
+SET character_set_client = @saved_cs_client;
+DROP TABLE IF EXISTS `loads`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `loads` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `one` float NOT NULL DEFAULT 0,
+  `five` float NOT NULL DEFAULT 0,
+  `fifteen` float NOT NULL DEFAULT 0,
+  `online` int(11) NOT NULL DEFAULT 0,
+  `created_at` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `majors`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `majors` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `parent_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `name` varchar(32) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `parent_id` (`parent_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=70 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `notes`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `notes` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `from_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `to_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `message` text NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  `read_at` datetime NOT NULL DEFAULT '1001-01-01 00:00:00',
+  PRIMARY KEY (`id`),
+  KEY `from_id` (`from_id`),
+  KEY `to_id` (`to_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `registers`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `registers` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `pin` int(10) unsigned NOT NULL DEFAULT 0,
+  `ki` int(10) unsigned NOT NULL DEFAULT 0,
+  `name` varchar(16) DEFAULT NULL,
+  `born_on` date DEFAULT NULL,
+  `died_on` date DEFAULT NULL,
+  `category` enum('졸업','수료','조졸','전학','자퇴','재학','기타') NOT NULL DEFAULT '재학',
+  `remarks` varchar(32) NOT NULL DEFAULT '',
+  `uid` mediumint(8) unsigned DEFAULT NULL,
+  `member_status` enum('정','준','') DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `ki` (`ki`,`name`),
+  KEY `name` (`name`)
+) ENGINE=MyISAM AUTO_INCREMENT=5570 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `schools`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `schools` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `full_name` varchar(128) NOT NULL DEFAULT '',
+  `brief_name` varchar(32) NOT NULL DEFAULT '',
+  `url` varchar(64) DEFAULT NULL,
+  `country_code` varchar(2) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `full_name` (`full_name`),
+  KEY `brief_name` (`brief_name`)
+) ENGINE=MyISAM AUTO_INCREMENT=222 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!50001 DROP VIEW IF EXISTS `freq_bookmark`*/;
+/*!50001 SET @saved_cs_client          = @@character_set_client */;
+/*!50001 SET @saved_cs_results         = @@character_set_results */;
+/*!50001 SET @saved_col_connection     = @@collation_connection */;
+/*!50001 SET character_set_client      = utf8mb3 */;
+/*!50001 SET character_set_results     = utf8mb3 */;
+/*!50001 SET collation_connection      = utf8mb3_general_ci */;
+/*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`bawi`@`localhost` SQL SECURITY DEFINER */
+/*!50001 VIEW `freq_bookmark` AS select count(0) AS `count`,`bw_xboard_bookmark`.`uid` AS `uid` from `bw_xboard_bookmark` group by `bw_xboard_bookmark`.`uid` order by count(0) desc */;
+/*!50001 SET character_set_client      = @saved_cs_client */;
+/*!50001 SET character_set_results     = @saved_cs_results */;
+/*!50001 SET collation_connection      = @saved_col_connection */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+

--- a/docker/db/init/15-baseline.sql
+++ b/docker/db/init/15-baseline.sql
@@ -1,0 +1,24 @@
+-- Pre-recorded migration state for the schema dump in 10-schema.sql.
+--
+-- Every db/YYYYMMDD_*.sql migration whose change is ALREADY CONTAINED in that
+-- dump must have a 'baseline' row here, so 20-apply-migrations.sh skips it
+-- instead of re-executing it (which would abort first-boot init, e.g. on a
+-- duplicate CREATE TABLE).
+--
+-- REGENERATE THIS LIST WHENEVER 10-schema.sql IS REFRESHED: add a baseline
+-- row for every dated migration the new dump now includes. The current dump
+-- (prod, 2026-07-06, structure only) predates the career-v3.2 and body_html
+-- migrations, so those two are NOT baselined and execute on first init.
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  filename   varchar(128) NOT NULL,
+  status     enum('applied','baseline') NOT NULL,
+  applied_at datetime NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (filename)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO schema_migrations (filename, status) VALUES
+  ('20161225_add_career_enum.sql',                   'baseline'),
+  ('20201030_add_expiration_days.sql',               'baseline'),
+  ('20201031_create_commentref.sql',                 'baseline'),
+  ('20220903_add_retraction.sql',                    'baseline'),
+  ('20221221_retroactive_change_delete_comment.sql', 'baseline');

--- a/docker/db/init/15-baseline.sql
+++ b/docker/db/init/15-baseline.sql
@@ -1,14 +1,20 @@
 -- Pre-recorded migration state for the schema dump in 10-schema.sql.
 --
--- Every db/YYYYMMDD_*.sql migration whose change is ALREADY CONTAINED in that
--- dump must have a 'baseline' row here, so 20-apply-migrations.sh skips it
--- instead of re-executing it (which would abort first-boot init, e.g. on a
--- duplicate CREATE TABLE).
+-- Every db/YYYYMMDD_*.sql migration whose change prod had already applied
+-- when that dump was taken must have a 'baseline' row here, so
+-- 20-apply-migrations.sh skips it instead of re-executing it. (Data-only
+-- migrations prod has run are baselined too, even though a structure-only
+-- dump can't literally contain their effect.)
 --
 -- REGENERATE THIS LIST WHENEVER 10-schema.sql IS REFRESHED: add a baseline
--- row for every dated migration the new dump now includes. The current dump
--- (prod, 2026-07-06, structure only) predates the career-v3.2 and body_html
--- migrations, so those two are NOT baselined and execute on first init.
+-- row for every dated migration the new dump reflects. A missed entry gets
+-- re-executed on first boot — non-idempotent DDL aborts loudly (duplicate
+-- CREATE TABLE), but idempotent migrations (ALTER MODIFY, data UPDATEs,
+-- DROP IF EXISTS+CREATE) re-run SILENTLY, so verify those by hand.
+--
+-- The current dump (prod, 2026-07-06, structure only) predates
+-- 20260708_create_career.sql (career v3.2) and 20260712_create_body_html.sql,
+-- so those two are NOT baselined and execute on first init.
 CREATE TABLE IF NOT EXISTS schema_migrations (
   filename   varchar(128) NOT NULL,
   status     enum('applied','baseline') NOT NULL,
@@ -16,7 +22,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
   PRIMARY KEY (filename)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-INSERT IGNORE INTO schema_migrations (filename, status) VALUES
+INSERT INTO schema_migrations (filename, status) VALUES
   ('20161225_add_career_enum.sql',                   'baseline'),
   ('20201030_add_expiration_days.sql',               'baseline'),
   ('20201031_create_commentref.sql',                 'baseline'),

--- a/docker/db/init/20-apply-migrations.sh
+++ b/docker/db/init/20-apply-migrations.sh
@@ -6,7 +6,8 @@
 # in db/ are legacy FULL DUMPS and are never executed; any other *.sql name
 # is skipped with a loud warning (rename it to the dated pattern to run it).
 # Data in migrations: transforms of existing rows are fine (reseed
-# regenerates data in final shape). Reference rows prod needs MAY ride in
+# regenerates data — keep seed.pl emitting the post-migration shape).
+# Reference rows prod needs MAY ride in
 # the migration (idempotently) for prod's sake — db/ is also the prod
 # migration channel — but MUST then be mirrored in seed/seed.pl, because
 # reseed truncates every base table except schema_migrations.

--- a/docker/db/init/20-apply-migrations.sh
+++ b/docker/db/init/20-apply-migrations.sh
@@ -1,42 +1,47 @@
 #!/bin/bash
-# Guarded migration runner for the bawi test database.
+# Migration runner for the bawi test database.
 #
-# Applies db/*.sql (mounted at /bawi-migrations) in chronological order
-# (filenames start with YYYYMMDD, so lexicographic glob order == date order),
-# guarding against double-apply two ways:
+# CONTRACT: dated migrations are db/YYYYMMDD_*.sql (mounted read-only at
+# /bawi-migrations); lexicographic order == date order. The bawi_*.sql files
+# in db/ are legacy FULL DUMPS and are never executed; any other *.sql name
+# is skipped with a loud warning (rename it to the dated pattern to run it).
 #
-#   1. A `schema_migrations` tracking table records every processed file.
-#   2. For each known migration, an information_schema probe detects whether
-#      the change is ALREADY REFLECTED in the loaded schema dump (the current
-#      prod schema contains all five historical migrations); such files are
-#      recorded as status='baseline' without being executed.
+# Double-apply protection is the schema_migrations tracking table alone:
+# migrations already contained in 10-schema.sql are pre-recorded as
+# status='baseline' by 15-baseline.sql (which runs first and also creates the
+# table); everything not recorded is executed and recorded as 'applied'.
+# REFRESHING THE DUMP: update 15-baseline.sql in the same commit — a
+# migration the new dump contains but the baseline list misses will be
+# re-executed and abort first boot.
 #
-# New migration files dropped into db/ are simply executed (status='applied'):
-# either re-run this script (see below) or `docker compose down -v && up` for
-# a fresh init.
-#
-# Runs in two contexts:
-#   a) automatically, as a /docker-entrypoint-initdb.d/*.sh hook on FIRST
-#      container init (the official mariadb entrypoint sources it, providing
-#      docker_process_sql);
-#   b) manually, against a running db container:
+# This file is executable ON PURPOSE: the official mariadb entrypoint runs
+# executable init hooks as a child process (it would source a non-executable
+# one into its own shell, leaking our set -e/shopt). Both contexts therefore
+# use the plain client below:
+#   a) first-boot init hook — the entrypoint's temp server listens on the
+#      default socket and the root password is already set. Requires the
+#      plain MARIADB_ROOT_PASSWORD env form (a _FILE/RANDOM variant would
+#      break the client call below).
+#   b) manual rerun on a running container (e.g. after adding a migration):
 #      docker compose exec db bash /docker-entrypoint-initdb.d/20-apply-migrations.sh
 set -euo pipefail
 
 MIGRATIONS_DIR="${MIGRATIONS_DIR:-/bawi-migrations}"
 DB_NAME="${MARIADB_DATABASE:-bawi}"
 
-if declare -F docker_process_sql >/dev/null 2>&1; then
-    # initdb context (temp server on unix socket, helper provided)
-    sql_exec() { docker_process_sql --database="$DB_NAME" "$@"; }
-else
-    # exec context on a running container
-    sql_exec() { mariadb -uroot -p"${MARIADB_ROOT_PASSWORD:?}" --database="$DB_NAME" "$@"; }
-fi
+sql_exec() { mariadb -uroot -p"${MARIADB_ROOT_PASSWORD:?}" --database="$DB_NAME" "$@"; }
 
-q() { echo "$1" | sql_exec --skip-column-names --batch; }
+# Scalar query with a fail-closed error path: a failed probe must abort, not
+# read as an answer (an empty result here once meant "skip this migration").
+sql_query() {
+    local out
+    out=$(echo "$1" | sql_exec --skip-column-names --batch) \
+        || { echo "[migrations] FATAL: query failed: $1" >&2; exit 1; }
+    echo "$out"
+}
 
-echo "[migrations] ensuring schema_migrations tracking table"
+# 15-baseline.sql creates the tracking table on first init; ensure it exists
+# for manual reruns against DBs initialized before that file existed.
 sql_exec <<'SQL'
 CREATE TABLE IF NOT EXISTS schema_migrations (
   filename   varchar(128) NOT NULL,
@@ -47,70 +52,43 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 SQL
 
 is_recorded() {
-    [ "$(q "SELECT COUNT(*) FROM schema_migrations WHERE filename='$1'")" != "0" ]
+    local n
+    n=$(sql_query "SELECT COUNT(*) FROM schema_migrations WHERE filename='$1'")
+    case "$n" in
+        0) return 1 ;;
+        1) return 0 ;;
+        # "" here means the sql_query subshell failed (its FATAL is on stderr)
+        *) echo "[migrations] FATAL: unexpected probe result '$n' for $1" >&2; exit 1 ;;
+    esac
 }
 
 record() {
     echo "INSERT INTO schema_migrations (filename, status) VALUES ('$1', '$2')" | sql_exec
 }
 
-# Echo a non-zero count if the migration's effect is already present.
-already_reflected() {
-    case "$1" in
-        20161225_add_career_enum.sql)
-            q "SELECT COUNT(*) FROM information_schema.COLUMNS
-               WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='bw_user_degree'
-                 AND COLUMN_NAME='type' AND COLUMN_TYPE LIKE '%Postdoc%'"
-            ;;
-        20201030_add_expiration_days.sql)
-            q "SELECT COUNT(*) FROM information_schema.COLUMNS
-               WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='bw_xboard_board'
-                 AND COLUMN_NAME='expire_days'"
-            ;;
-        20201031_create_commentref.sql)
-            q "SELECT COUNT(*) FROM information_schema.TABLES
-               WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='bw_xboard_commentref'"
-            ;;
-        20220903_add_retraction.sql)
-            q "SELECT COUNT(*) FROM information_schema.COLUMNS
-               WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='bw_xboard_recom'
-                 AND COLUMN_NAME='retracttime'"
-            ;;
-        20221221_retroactive_change_delete_comment.sql)
-            # Data-only fix (idempotent UPDATE). "Reflected" when no rows
-            # still carry the old placeholder text — trivially true on a
-            # fresh structure-only load.
-            local n
-            n=$(q "SELECT COUNT(*) FROM bw_xboard_comment
-                   WHERE body LIKE '** Deleted by the author **'
-                      OR body LIKE '*** Deleted by author ***'")
-            if [ "$n" = "0" ]; then echo 1; else echo 0; fi
-            ;;
-        *)
-            echo 0   # unknown/new migration: not reflected -> execute it
-            ;;
-    esac
-}
-
 shopt -s nullglob
 found=0
-for f in "$MIGRATIONS_DIR"/2*.sql; do
-    found=1
+for f in "$MIGRATIONS_DIR"/*.sql; do
     base=$(basename "$f")
+    case "$base" in
+        [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_*.sql) ;;
+        bawi_*.sql)
+            echo "[migrations] $base: legacy full dump — never executed"
+            continue ;;
+        *)
+            echo "[migrations] WARNING: $base does not match YYYYMMDD_*.sql — NOT applied (rename it to run)" >&2
+            continue ;;
+    esac
+    found=1
     if is_recorded "$base"; then
         echo "[migrations] $base: already recorded — skip"
         continue
     fi
-    if [ "$(already_reflected "$base")" != "0" ]; then
-        echo "[migrations] $base: already reflected in schema — recording as baseline"
-        record "$base" baseline
-    else
-        echo "[migrations] $base: applying"
-        sql_exec < "$f"
-        record "$base" applied
-    fi
+    echo "[migrations] $base: applying"
+    sql_exec < "$f"
+    record "$base" applied
 done
-[ "$found" = "1" ] || echo "[migrations] WARNING: no migration files found in $MIGRATIONS_DIR"
+[ "$found" = "1" ] || echo "[migrations] WARNING: no dated migration files found in $MIGRATIONS_DIR"
 
 echo "[migrations] state:"
-q "SELECT CONCAT(filename, ' -> ', status) FROM schema_migrations ORDER BY filename"
+sql_query "SELECT CONCAT(filename, ' -> ', status) FROM schema_migrations ORDER BY filename"

--- a/docker/db/init/20-apply-migrations.sh
+++ b/docker/db/init/20-apply-migrations.sh
@@ -10,14 +10,16 @@
 # migrations already contained in 10-schema.sql are pre-recorded as
 # status='baseline' by 15-baseline.sql (which runs first and also creates the
 # table); everything not recorded is executed and recorded as 'applied'.
-# REFRESHING THE DUMP: update 15-baseline.sql in the same commit — a
-# migration the new dump contains but the baseline list misses will be
-# re-executed and abort first boot.
+# REFRESHING THE DUMP: update 15-baseline.sql in the same commit — a missed
+# baseline entry gets re-executed: non-idempotent DDL aborts first boot
+# loudly, but idempotent migrations (ALTER MODIFY, data UPDATEs, DROP IF
+# EXISTS+CREATE) re-run SILENTLY — verify those rows by hand.
 #
 # This file is executable ON PURPOSE: the official mariadb entrypoint runs
 # executable init hooks as a child process (it would source a non-executable
-# one into its own shell, leaking our set -e/shopt). Both contexts therefore
-# use the plain client below:
+# one into its own shell, leaking our set -e/shopt). The child doesn't
+# inherit the entrypoint's internal SQL helper functions, so both contexts
+# call the plain mariadb client below:
 #   a) first-boot init hook — the entrypoint's temp server listens on the
 #      default socket and the root password is already set. Requires the
 #      plain MARIADB_ROOT_PASSWORD env form (a _FILE/RANDOM variant would
@@ -31,8 +33,8 @@ DB_NAME="${MARIADB_DATABASE:-bawi}"
 
 sql_exec() { mariadb -uroot -p"${MARIADB_ROOT_PASSWORD:?}" --database="$DB_NAME" "$@"; }
 
-# Scalar query with a fail-closed error path: a failed probe must abort, not
-# read as an answer (an empty result here once meant "skip this migration").
+# Query with a fail-closed error path: a failed probe must abort, not read
+# as an answer (an empty result here once meant "skip this migration").
 sql_query() {
     local out
     out=$(echo "$1" | sql_exec --skip-column-names --batch) \
@@ -40,16 +42,16 @@ sql_query() {
     echo "$out"
 }
 
-# 15-baseline.sql creates the tracking table on first init; ensure it exists
-# for manual reruns against DBs initialized before that file existed.
-sql_exec <<'SQL'
-CREATE TABLE IF NOT EXISTS schema_migrations (
-  filename   varchar(128) NOT NULL,
-  status     enum('applied','baseline') NOT NULL,
-  applied_at datetime NOT NULL DEFAULT current_timestamp(),
-  PRIMARY KEY (filename)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-SQL
+# 15-baseline.sql owns the tracking table and its baseline rows (first-boot
+# init runs it before this script). A missing/empty table here means the DB
+# was never legitimately initialized (e.g. a first boot that died mid-schema,
+# then restarted with a non-empty datadir, which skips init) — re-executing
+# migrations against unknown state is wrong, so fail closed.
+recorded=$(sql_query "SELECT COUNT(*) FROM schema_migrations" 2>/dev/null) || recorded=""
+if [ -z "$recorded" ] || [ "$recorded" = "0" ]; then
+    echo "[migrations] FATAL: schema_migrations is missing or empty — this DB was not initialized by 15-baseline.sql (a failed first boot?). Rebuild with: docker compose down -v && docker compose up -d" >&2
+    exit 1
+fi
 
 is_recorded() {
     local n
@@ -88,7 +90,12 @@ for f in "$MIGRATIONS_DIR"/*.sql; do
     sql_exec < "$f"
     record "$base" applied
 done
-[ "$found" = "1" ] || echo "[migrations] WARNING: no dated migration files found in $MIGRATIONS_DIR"
+if [ "$found" != "1" ]; then
+    # The repo always ships dated migrations; an empty dir means a broken
+    # mount or MIGRATIONS_DIR override — never a state to bless silently.
+    echo "[migrations] FATAL: no dated migration files found in $MIGRATIONS_DIR" >&2
+    exit 1
+fi
 
 echo "[migrations] state:"
 sql_query "SELECT CONCAT(filename, ' -> ', status) FROM schema_migrations ORDER BY filename"

--- a/docker/db/init/20-apply-migrations.sh
+++ b/docker/db/init/20-apply-migrations.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Guarded migration runner for the bawi test database.
+#
+# Applies db/*.sql (mounted at /bawi-migrations) in chronological order
+# (filenames start with YYYYMMDD, so lexicographic glob order == date order),
+# guarding against double-apply two ways:
+#
+#   1. A `schema_migrations` tracking table records every processed file.
+#   2. For each known migration, an information_schema probe detects whether
+#      the change is ALREADY REFLECTED in the loaded schema dump (the current
+#      prod schema contains all five historical migrations); such files are
+#      recorded as status='baseline' without being executed.
+#
+# New migration files dropped into db/ are simply executed (status='applied'):
+# either re-run this script (see below) or `docker compose down -v && up` for
+# a fresh init.
+#
+# Runs in two contexts:
+#   a) automatically, as a /docker-entrypoint-initdb.d/*.sh hook on FIRST
+#      container init (the official mariadb entrypoint sources it, providing
+#      docker_process_sql);
+#   b) manually, against a running db container:
+#      docker compose exec db bash /docker-entrypoint-initdb.d/20-apply-migrations.sh
+set -euo pipefail
+
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-/bawi-migrations}"
+DB_NAME="${MARIADB_DATABASE:-bawi}"
+
+if declare -F docker_process_sql >/dev/null 2>&1; then
+    # initdb context (temp server on unix socket, helper provided)
+    sql_exec() { docker_process_sql --database="$DB_NAME" "$@"; }
+else
+    # exec context on a running container
+    sql_exec() { mariadb -uroot -p"${MARIADB_ROOT_PASSWORD:?}" --database="$DB_NAME" "$@"; }
+fi
+
+q() { echo "$1" | sql_exec --skip-column-names --batch; }
+
+echo "[migrations] ensuring schema_migrations tracking table"
+sql_exec <<'SQL'
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  filename   varchar(128) NOT NULL,
+  status     enum('applied','baseline') NOT NULL,
+  applied_at datetime NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (filename)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+
+is_recorded() {
+    [ "$(q "SELECT COUNT(*) FROM schema_migrations WHERE filename='$1'")" != "0" ]
+}
+
+record() {
+    echo "INSERT INTO schema_migrations (filename, status) VALUES ('$1', '$2')" | sql_exec
+}
+
+# Echo a non-zero count if the migration's effect is already present.
+already_reflected() {
+    case "$1" in
+        20161225_add_career_enum.sql)
+            q "SELECT COUNT(*) FROM information_schema.COLUMNS
+               WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='bw_user_degree'
+                 AND COLUMN_NAME='type' AND COLUMN_TYPE LIKE '%Postdoc%'"
+            ;;
+        20201030_add_expiration_days.sql)
+            q "SELECT COUNT(*) FROM information_schema.COLUMNS
+               WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='bw_xboard_board'
+                 AND COLUMN_NAME='expire_days'"
+            ;;
+        20201031_create_commentref.sql)
+            q "SELECT COUNT(*) FROM information_schema.TABLES
+               WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='bw_xboard_commentref'"
+            ;;
+        20220903_add_retraction.sql)
+            q "SELECT COUNT(*) FROM information_schema.COLUMNS
+               WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='bw_xboard_recom'
+                 AND COLUMN_NAME='retracttime'"
+            ;;
+        20221221_retroactive_change_delete_comment.sql)
+            # Data-only fix (idempotent UPDATE). "Reflected" when no rows
+            # still carry the old placeholder text — trivially true on a
+            # fresh structure-only load.
+            local n
+            n=$(q "SELECT COUNT(*) FROM bw_xboard_comment
+                   WHERE body LIKE '** Deleted by the author **'
+                      OR body LIKE '*** Deleted by author ***'")
+            if [ "$n" = "0" ]; then echo 1; else echo 0; fi
+            ;;
+        *)
+            echo 0   # unknown/new migration: not reflected -> execute it
+            ;;
+    esac
+}
+
+shopt -s nullglob
+found=0
+for f in "$MIGRATIONS_DIR"/2*.sql; do
+    found=1
+    base=$(basename "$f")
+    if is_recorded "$base"; then
+        echo "[migrations] $base: already recorded — skip"
+        continue
+    fi
+    if [ "$(already_reflected "$base")" != "0" ]; then
+        echo "[migrations] $base: already reflected in schema — recording as baseline"
+        record "$base" baseline
+    else
+        echo "[migrations] $base: applying"
+        sql_exec < "$f"
+        record "$base" applied
+    fi
+done
+[ "$found" = "1" ] || echo "[migrations] WARNING: no migration files found in $MIGRATIONS_DIR"
+
+echo "[migrations] state:"
+q "SELECT CONCAT(filename, ' -> ', status) FROM schema_migrations ORDER BY filename"

--- a/docker/db/init/20-apply-migrations.sh
+++ b/docker/db/init/20-apply-migrations.sh
@@ -5,8 +5,10 @@
 # /bawi-migrations); lexicographic order == date order. The bawi_*.sql files
 # in db/ are legacy FULL DUMPS and are never executed; any other *.sql name
 # is skipped with a loud warning (rename it to the dated pattern to run it).
-# Migrations must be structure-only or idempotent data transforms: reference
-# rows a migration would INSERT belong in seed/seed.pl instead, because
+# Data in migrations: transforms of existing rows are fine (reseed
+# regenerates data in final shape). Reference rows prod needs MAY ride in
+# the migration (idempotently) for prod's sake — db/ is also the prod
+# migration channel — but MUST then be mirrored in seed/seed.pl, because
 # reseed truncates every base table except schema_migrations.
 #
 # Double-apply protection is the schema_migrations tracking table alone:

--- a/docker/db/init/20-apply-migrations.sh
+++ b/docker/db/init/20-apply-migrations.sh
@@ -35,7 +35,7 @@
 set -euo pipefail
 
 MIGRATIONS_DIR="${MIGRATIONS_DIR:-/bawi-migrations}"
-DB_NAME="${MARIADB_DATABASE:-bawi}"
+DB_NAME="${MARIADB_DATABASE:?}"
 
 sql_exec() { mariadb -uroot -p"${MARIADB_ROOT_PASSWORD:?}" --database="$DB_NAME" "$@"; }
 

--- a/docker/db/init/20-apply-migrations.sh
+++ b/docker/db/init/20-apply-migrations.sh
@@ -5,6 +5,9 @@
 # /bawi-migrations); lexicographic order == date order. The bawi_*.sql files
 # in db/ are legacy FULL DUMPS and are never executed; any other *.sql name
 # is skipped with a loud warning (rename it to the dated pattern to run it).
+# Migrations must be structure-only or idempotent data transforms: reference
+# rows a migration would INSERT belong in seed/seed.pl instead, because
+# reseed truncates every base table except schema_migrations.
 #
 # Double-apply protection is the schema_migrations tracking table alone:
 # migrations already contained in 10-schema.sql are pre-recorded as
@@ -42,11 +45,16 @@ sql_query() {
     echo "$out"
 }
 
+# Connectivity first, stderr unsuppressed: a down/starting server or bad
+# credentials must abort with the client's real error ("retry"), never be
+# mistaken for the missing-ledger state whose remedy (down -v) is destructive.
+sql_query "SELECT 1" >/dev/null
+
 # 15-baseline.sql owns the tracking table and its baseline rows (first-boot
-# init runs it before this script). A missing/empty table here means the DB
-# was never legitimately initialized (e.g. a first boot that died mid-schema,
-# then restarted with a non-empty datadir, which skips init) — re-executing
-# migrations against unknown state is wrong, so fail closed.
+# init runs it before this script). With the DB reachable, a missing/empty
+# table means the DB was never legitimately initialized (e.g. a first boot
+# that died mid-schema, then restarted with a non-empty datadir, which skips
+# init) — re-executing migrations against unknown state is wrong, fail closed.
 recorded=$(sql_query "SELECT COUNT(*) FROM schema_migrations" 2>/dev/null) || recorded=""
 if [ -z "$recorded" ] || [ "$recorded" = "0" ]; then
     echo "[migrations] FATAL: schema_migrations is missing or empty — this DB was not initialized by 15-baseline.sql (a failed first boot?). Rebuild with: docker compose down -v && docker compose up -d" >&2

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,76 @@
+# Web container for the bawi-on-perl LOCAL test environment.
+# Mirrors production: Ubuntu 22.04, Apache 2.4 + mod_perl2 (ModPerl::Registry),
+# Perl 5.34, MariaDB client libs. The application code is NOT baked into the
+# image — the repo working tree is bind-mounted at /home/bawi/bawi-spring.
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Core stack + every Perl module the app needs:
+#   libapache2-mod-perl2   -> mod_perl2 / ModPerl::Registry
+#   libapache-dbi-perl     -> Apache::DBI (persistent DB handles)
+#   libdbd-mysql-perl      -> DBD::mysql (DSNs are "dbi:mysql:...")
+#   libcgi-pm-perl         -> CGI, CGI::Cookie
+#   libhtml-template-perl  -> HTML::Template
+#   libimage-magick-perl   -> Image::Magick (PerlMagick)
+#   libtext-iconv-perl     -> Text::Iconv
+#   liburi-perl            -> URI::Escape
+#   libjson-perl, libgd-perl -> JSON / GD (used by a couple of stat scripts)
+#   Locale::Maketext, Digest::MD5, HTTP::Tiny, Encode, Benchmark -> perl core
+# GeoIP2::WebService::Client is intentionally NOT installed: nothing on the
+# resp2 branch imports it (verified by grep); it belongs to a skipped
+# optional feature.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        apache2 \
+        libapache2-mod-perl2 \
+        libapache-dbi-perl \
+        libdbi-perl \
+        libdbd-mysql-perl \
+        libcgi-pm-perl \
+        libhtml-template-perl \
+        libimage-magick-perl \
+        libtext-iconv-perl \
+        liburi-perl \
+        libjson-perl \
+        libgd-perl \
+        mariadb-client \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# HTML::ParseBrowser is a HARD dependency of Bawi::Auth (used on every
+# authenticated request) — despite being listed alongside the optional GeoIP
+# feature. Prefer the Ubuntu package; fall back to CPAN if unavailable.
+RUN apt-get update \
+    && ( apt-get install -y --no-install-recommends libhtml-parsebrowser-perl \
+         || ( apt-get install -y --no-install-recommends cpanminus make \
+              && cpanm --notest HTML::ParseBrowser ) ) \
+    && rm -rf /var/lib/apt/lists/*
+
+# Fail the build early if any compile-time dependency is missing.
+RUN perl -MApache::DBI -MDBI -MDBD::mysql -MCGI -MCGI::Cookie \
+         -MHTML::Template -MImage::Magick -MText::Iconv -MHTML::ParseBrowser \
+         -MURI::Escape -MLocale::Maketext -MJSON -MGD -MDigest::MD5 \
+         -e 'print "perl deps OK\n"'
+
+# Apache: prefork MPM (legacy CGI-style app, matches prod), mod_perl,
+# plain mod_cgi for the couple of AddHandler'd .pl scripts.
+RUN a2dismod -q mpm_event \
+    && a2enmod -q mpm_prefork perl cgi include rewrite \
+    && a2dissite -q 000-default
+
+COPY bawi-test.conf /etc/apache2/sites-available/bawi-test.conf
+RUN a2ensite -q bawi-test
+
+# Route Apache's GLOBAL logs to the container's stdout/stderr so Perl
+# warn()/die() output (which lands in the global error log, not the vhost
+# log) shows up in `docker compose logs web`.
+RUN ln -sfT /dev/stderr /var/log/apache2/error.log \
+    && ln -sfT /dev/stdout /var/log/apache2/access.log \
+    && ln -sfT /dev/stdout /var/log/apache2/other_vhosts_access.log
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -36,7 +36,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libjson-perl \
         libgd-perl \
         mariadb-client \
-        curl \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -6,20 +6,22 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Core stack + every Perl module the app needs:
-#   libapache2-mod-perl2   -> mod_perl2 / ModPerl::Registry
-#   libapache-dbi-perl     -> Apache::DBI (persistent DB handles)
-#   libdbd-mysql-perl      -> DBD::mysql (DSNs are "dbi:mysql:...")
-#   libcgi-pm-perl         -> CGI, CGI::Cookie
-#   libhtml-template-perl  -> HTML::Template
-#   libimage-magick-perl   -> Image::Magick (PerlMagick)
-#   libtext-iconv-perl     -> Text::Iconv
-#   liburi-perl            -> URI::Escape
-#   libjson-perl, libgd-perl -> JSON / GD (used by a couple of stat scripts)
+# Core stack + every EXTERNAL Perl module the app needs:
+#   libapache2-mod-perl2      -> mod_perl2 / ModPerl::Registry
+#   libapache-dbi-perl        -> Apache::DBI (persistent DB handles)
+#   libdbd-mysql-perl         -> DBD::mysql (DSNs are "dbi:mysql:...")
+#   libcgi-pm-perl            -> CGI, CGI::Cookie
+#   libhtml-template-perl     -> HTML::Template
+#   libimage-magick-perl      -> Image::Magick (PerlMagick)
+#   libtext-iconv-perl        -> Text::Iconv
+#   liburi-perl               -> URI::Escape
+#   libjson-perl              -> JSON (board/comment.cgi Twitter embed)
+#   libgd-perl                -> GD (main/process/graph.cgi)
 #   Locale::Maketext, Digest::MD5, HTTP::Tiny, Encode, Benchmark -> perl core
-# GeoIP2::WebService::Client is intentionally NOT installed: nothing on the
-# resp2 branch imports it (verified by grep); it belongs to a skipped
-# optional feature.
+# Text::Markdown needs no package: it is vendored at lib/Text/Markdown.pm and
+# resolved via startup.pl's `use lib`. GeoIP2::WebService::Client is
+# intentionally NOT installed: nothing in this repo imports it (verified by
+# grep); it belongs to a skipped optional feature.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apache2 \
         libapache2-mod-perl2 \
@@ -38,13 +40,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# HTML::ParseBrowser is a HARD dependency of Bawi::Auth (used on every
-# authenticated request) — despite being listed alongside the optional GeoIP
-# feature. Prefer the Ubuntu package; fall back to CPAN if unavailable.
+# HTML::ParseBrowser is a HARD dependency of Bawi::Auth (use'd at
+# lib/Bawi/Auth.pm:10, hit on every login) but is NOT packaged in Ubuntu
+# 22.04 ("Unable to locate package libhtml-parsebrowser-perl") — install it
+# from CPAN. The perl -M gate below fails the build if this ever breaks.
 RUN apt-get update \
-    && ( apt-get install -y --no-install-recommends libhtml-parsebrowser-perl \
-         || ( apt-get install -y --no-install-recommends cpanminus make \
-              && cpanm --notest HTML::ParseBrowser ) ) \
+    && apt-get install -y --no-install-recommends cpanminus make \
+    && cpanm --notest HTML::ParseBrowser \
     && rm -rf /var/lib/apt/lists/*
 
 # Fail the build early if any compile-time dependency is missing.

--- a/docker/web/bawi-test.conf
+++ b/docker/web/bawi-test.conf
@@ -27,15 +27,6 @@
   Alias /xboard/  /home/bawi/bawi-spring/board/
   Alias /admin/   /home/bawi/bawi-spring/admin/
 
-  # Preload CGI::Cookie into the parent interpreter. lib/Bawi/Main/UI.pm
-  # calls `CGI::Cookie->fetch` without loading the module — it only works when
-  # something else (normally Bawi::Auth, use'd by nearly every page) loaded it
-  # first in the same Apache child. On prod that is virtually always true; in
-  # a fresh child serving e.g. main/db-test.cgi (which skips Bawi::Auth) it
-  # 500s. Preloading here removes the load-order dependency WITHOUT touching
-  # app code. (Latent app bug.)
-  PerlModule CGI::Cookie
-
   PerlPostConfigRequire /home/bawi/bawi-spring/apache2/startup.pl
 
   <Directory />

--- a/docker/web/bawi-test.conf
+++ b/docker/web/bawi-test.conf
@@ -6,6 +6,7 @@
 #   - Apache 2.2 "Order/Allow" lines replaced by their 2.4 equivalent
 #     "Require all granted" (prod relies on mod_access_compat for those)
 #   - logs to stdout/stderr for `docker compose logs`
+#   - explicit DirectoryIndex (prod relies on the distro-global dir.conf)
 # Everything the app depends on is identical: DocumentRoot, aliases,
 # ModPerl::Registry handlers, and PerlPostConfigRequire of startup.pl.
 <VirtualHost *:80>

--- a/docker/web/bawi-test.conf
+++ b/docker/web/bawi-test.conf
@@ -1,0 +1,116 @@
+# Test-environment vhost for bawi-on-perl.
+# Mirrors the production vhost (apache2/bawi-spring, the *:443 block) with the
+# minimum test-env deltas:
+#   - plain HTTP on :80 (no TLS, no www.bawi.org rewrite) — the container port
+#     is published on 127.0.0.1 only (see docker-compose.yml)
+#   - Apache 2.2 "Order/Allow" lines replaced by their 2.4 equivalent
+#     "Require all granted" (prod relies on mod_access_compat for those)
+#   - logs to stdout/stderr for `docker compose logs`
+# Everything the app depends on is identical: DocumentRoot, aliases,
+# ModPerl::Registry handlers, and PerlPostConfigRequire of startup.pl.
+<VirtualHost *:80>
+  ServerAdmin webmaster@localhost
+  DocumentRoot /home/bawi/bawi-spring/main
+  ServerName localhost
+
+  LogLevel warn
+  ErrorLog /dev/stderr
+  CustomLog /dev/stdout combined
+
+  DirectoryIndex index.cgi index.html
+
+  Alias /main/    /home/bawi/bawi-spring/main/
+  Alias /board/   /home/bawi/bawi-spring/board/
+  Alias /user/    /home/bawi/bawi-spring/user/
+  Alias /reg/     /home/bawi/bawi-spring/reg/
+  Alias /x/       /home/bawi/bawi-spring/board/
+  Alias /xboard/  /home/bawi/bawi-spring/board/
+  Alias /admin/   /home/bawi/bawi-spring/admin/
+
+  # Preload CGI::Cookie into the parent interpreter. lib/Bawi/Main/UI.pm
+  # calls `CGI::Cookie->fetch` without loading the module — it only works when
+  # something else (normally Bawi::Auth, use'd by nearly every page) loaded it
+  # first in the same Apache child. On prod that is virtually always true; in
+  # a fresh child serving e.g. main/db-test.cgi (which skips Bawi::Auth) it
+  # 500s. Preloading here removes the load-order dependency WITHOUT touching
+  # app code. (Latent app bug.)
+  PerlModule CGI::Cookie
+
+  PerlPostConfigRequire /home/bawi/bawi-spring/apache2/startup.pl
+
+  <Directory />
+    Options FollowSymLinks
+    AllowOverride None
+  </Directory>
+
+  <Directory /home/bawi/bawi-spring/>
+    Options Indexes Includes FollowSymLinks MultiViews ExecCGI
+    AllowOverride All
+    Require all granted
+
+    AddHandler cgi-script .cgi
+  </Directory>
+
+  <Directory /home/bawi/bawi-spring/board/>
+    Options Indexes Includes FollowSymLinks MultiViews ExecCGI
+    Require all granted
+
+    <Files *.cgi>
+      SetHandler perl-script
+      PerlResponseHandler ModPerl::Registry
+      Options +ExecCGI
+    </Files>
+  </Directory>
+
+  <Directory /home/bawi/bawi-spring/reg/>
+    Options Indexes Includes FollowSymLinks MultiViews ExecCGI
+    AllowOverride None
+    Require all granted
+
+    <Files *.cgi>
+      SetHandler perl-script
+      PerlResponseHandler ModPerl::Registry
+      Options +ExecCGI
+    </Files>
+  </Directory>
+
+  <Directory /home/bawi/bawi-spring/user/>
+    Options Indexes Includes FollowSymLinks MultiViews ExecCGI
+    AllowOverride None
+    Require all granted
+
+    <Files *.cgi>
+      SetHandler perl-script
+      PerlResponseHandler ModPerl::Registry
+      Options +ExecCGI
+    </Files>
+  </Directory>
+
+  <Directory /home/bawi/bawi-spring/admin/>
+    Options Indexes Includes FollowSymLinks MultiViews ExecCGI
+    AllowOverride All
+    Require all granted
+
+    <Files *.cgi>
+      SetHandler perl-script
+      PerlResponseHandler ModPerl::Registry
+      Options +ExecCGI
+    </Files>
+  </Directory>
+
+  <Directory /home/bawi/bawi-spring/main/>
+    Options Indexes Includes FollowSymLinks MultiViews ExecCGI
+    AllowOverride None
+    Require all granted
+
+    AddHandler cgi-script .pl
+
+    <Files *.cgi>
+      SetHandler perl-script
+      PerlResponseHandler ModPerl::Registry
+      Options +ExecCGI
+    </Files>
+  </Directory>
+
+  # /server-status intentionally omitted in the test env.
+</VirtualHost>

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
 # Entrypoint for the bawi test web container.
-# 1. Prepare BAWI_DATA_HOME (attachment dir) with www-data ownership.
+# 1. Prepare BAWI_DATA_HOME (attachments) and the photo dir with www-data
+#    ownership. App config needs no step here: docker-compose.yml bind-mounts
+#    docker/conf/ read-only onto conf/, so the tracked test configs are always
+#    the live ones (edit docker/conf/*.conf on the host, restart web).
 # 2. Wait (bounded) for MariaDB so first-request behavior is deterministic.
 # 3. Run Apache in the foreground.
 set -e
 
 DATA_HOME=/home/bawi/bawi-data
 mkdir -p "$DATA_HOME/attach" "$DATA_HOME/tmp"
-chown -R www-data:www-data "$DATA_HOME"
-
-# Provide app config: conf/*.conf is gitignored (prod keeps its real configs
-# untracked there), so materialize the local test configs from docker/conf/
-# into the bind-mounted tree unless the host already has them.
-for f in /home/bawi/bawi-spring/docker/conf/*.conf; do
-    t="/home/bawi/bawi-spring/conf/$(basename "$f")"
-    [ -e "$t" ] || cp "$f" "$t"
-done
+# Photo storage: admin/uphoto.cgi, user/upload_photo.cgi et al. hardcode this
+# prod path; without it every photo page/upload 500s.
+PHOTO_HOME=/home/bawi/photo_attach
+mkdir -p "$PHOTO_HOME"
+chown -R www-data:www-data "$DATA_HOME" "$PHOTO_HOME"
 
 # Pass-through: `docker run <image> <cmd>` / compose `command:` runs <cmd>
 # instead of Apache (skips the DB wait).
@@ -37,6 +36,8 @@ for i in $(seq 1 90); do
     fi
     if [ "$i" -eq 90 ]; then
         echo "[entrypoint] WARNING: DB not reachable after 90s; starting Apache anyway" >&2
+        echo "[entrypoint] last attempt's error was:" >&2
+        mariadb -h"$DB_HOST" -u"$DB_USER" -p"$DB_PASS" "$DB_NAME" -e 'SELECT 1' >/dev/null || true
     fi
     sleep 1
 done

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -3,7 +3,8 @@
 # 1. Prepare BAWI_DATA_HOME (attachments) and the photo dir with www-data
 #    ownership. App config needs no step here: docker-compose.yml bind-mounts
 #    docker/conf/ read-only onto conf/, so the tracked test configs are always
-#    the live ones (edit docker/conf/*.conf on the host, restart web).
+#    the live ones (edit docker/conf/*.conf on the host — the app re-reads
+#    configs on every request, no restart needed).
 # 2. Wait (bounded) for MariaDB so first-request behavior is deterministic.
 # 3. Run Apache in the foreground.
 set -e
@@ -11,9 +12,10 @@ set -e
 DATA_HOME=/home/bawi/bawi-data
 mkdir -p "$DATA_HOME/attach" "$DATA_HOME/tmp"
 # Photo storage: admin/uphoto.cgi, user/upload_photo.cgi et al. hardcode this
-# prod path; without it every photo page/upload 500s.
+# prod path; without it every photo page/upload 500s. The updated/ subdir is
+# where admin/photo.cgi renames processed uploads.
 PHOTO_HOME=/home/bawi/photo_attach
-mkdir -p "$PHOTO_HOME"
+mkdir -p "$PHOTO_HOME/updated"
 chown -R www-data:www-data "$DATA_HOME" "$PHOTO_HOME"
 
 # Pass-through: `docker run <image> <cmd>` / compose `command:` runs <cmd>

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -27,17 +27,18 @@ DB_NAME="${BAWI_DB_NAME:-bawi}"
 DB_USER="${BAWI_DB_USER:-bawi_test}"
 DB_PASS="${BAWI_DB_PASS:-bawi-local-test-pw}"
 
+probe() { mariadb -h"$DB_HOST" -u"$DB_USER" -p"$DB_PASS" "$DB_NAME" -e 'SELECT 1' >/dev/null; }
+
 echo "[entrypoint] waiting for MariaDB at ${DB_HOST} (max 90s) ..."
 for i in $(seq 1 90); do
-    if mariadb -h"$DB_HOST" -u"$DB_USER" -p"$DB_PASS" "$DB_NAME" \
-               -e 'SELECT 1' >/dev/null 2>&1; then
+    if probe 2>/dev/null; then
         echo "[entrypoint] database is up (after ${i}s)"
         break
     fi
     if [ "$i" -eq 90 ]; then
         echo "[entrypoint] WARNING: DB not reachable after 90s; starting Apache anyway" >&2
-        echo "[entrypoint] last attempt's error was:" >&2
-        mariadb -h"$DB_HOST" -u"$DB_USER" -p"$DB_PASS" "$DB_NAME" -e 'SELECT 1' >/dev/null || true
+        echo "[entrypoint] retrying once to show the error:" >&2
+        probe || true
     fi
     sleep 1
 done

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Entrypoint for the bawi test web container.
+# 1. Prepare BAWI_DATA_HOME (attachment dir) with www-data ownership.
+# 2. Wait (bounded) for MariaDB so first-request behavior is deterministic.
+# 3. Run Apache in the foreground.
+set -e
+
+DATA_HOME=/home/bawi/bawi-data
+mkdir -p "$DATA_HOME/attach" "$DATA_HOME/tmp"
+chown -R www-data:www-data "$DATA_HOME"
+
+# Provide app config: conf/*.conf is gitignored (prod keeps its real configs
+# untracked there), so materialize the local test configs from docker/conf/
+# into the bind-mounted tree unless the host already has them.
+for f in /home/bawi/bawi-spring/docker/conf/*.conf; do
+    t="/home/bawi/bawi-spring/conf/$(basename "$f")"
+    [ -e "$t" ] || cp "$f" "$t"
+done
+
+# Pass-through: `docker run <image> <cmd>` / compose `command:` runs <cmd>
+# instead of Apache (skips the DB wait).
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
+DB_HOST="${BAWI_DB_HOST:-db}"
+DB_NAME="${BAWI_DB_NAME:-bawi}"
+DB_USER="${BAWI_DB_USER:-bawi_test}"
+DB_PASS="${BAWI_DB_PASS:-bawi-local-test-pw}"
+
+echo "[entrypoint] waiting for MariaDB at ${DB_HOST} (max 90s) ..."
+for i in $(seq 1 90); do
+    if mariadb -h"$DB_HOST" -u"$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+               -e 'SELECT 1' >/dev/null 2>&1; then
+        echo "[entrypoint] database is up (after ${i}s)"
+        break
+    fi
+    if [ "$i" -eq 90 ]; then
+        echo "[entrypoint] WARNING: DB not reachable after 90s; starting Apache anyway" >&2
+    fi
+    sleep 1
+done
+
+# Apache::DBI connects lazily per request, so Apache can start regardless.
+. /etc/apache2/envvars
+exec apache2 -D FOREGROUND

--- a/lib/Bawi/Main/UI.pm
+++ b/lib/Bawi/Main/UI.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Carp;
 use CGI;
-use CGI::Cookie;   # init() calls CGI::Cookie->fetch; don't rely on Bawi::Auth having loaded it
+use CGI::Cookie;   # is_mobile_device (called from init) uses CGI::Cookie->fetch; don't rely on Bawi::Auth having loaded it
 use File::Spec;
 use HTML::Template;
 use Text::Iconv;

--- a/lib/Bawi/Main/UI.pm
+++ b/lib/Bawi/Main/UI.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use Carp;
 use CGI;
+use CGI::Cookie;   # init() calls CGI::Cookie->fetch; don't rely on Bawi::Auth having loaded it
 use File::Spec;
 use HTML::Template;
 use Text::Iconv;

--- a/lib/Bawi/User/UI.pm
+++ b/lib/Bawi/User/UI.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use Carp;
 use CGI;
+use CGI::Cookie;   # is_mobile_device calls CGI::Cookie->fetch; don't rely on Bawi::Auth having loaded it
 use File::Spec;
 use HTML::Template;
 use Text::Iconv;

--- a/seed/reseed.sh
+++ b/seed/reseed.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Convenience wrapper: (re)seed the test DB with deterministic synthetic data.
+# Run from the repo root on the host. Requires the stack to be up.
+#   ./seed/reseed.sh
+# Works with both `docker compose` (v2) and legacy `docker-compose`.
+set -e
+cd "$(dirname "$0")/.."
+if docker compose version >/dev/null 2>&1; then
+    docker compose exec -T web perl /home/bawi/bawi-spring/seed/seed.pl
+else
+    docker-compose exec -T web perl /home/bawi/bawi-spring/seed/seed.pl
+fi

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -42,9 +42,9 @@
 #     from information_schema, so it can't drift), then reseeds — no UI
 #     experiment survives a "wipe + reseed".
 #     Deterministic caveat: columns with DEFAULT CURRENT_TIMESTAMP that the
-#     seeder leaves unset (bw_xboard_body.modified, bw_user_access
-#     .last_access, organizations.created_date) take the run's wall clock;
-#     every value the seeder writes explicitly is deterministic.
+#     seeder leaves unset (bw_xboard_body.modified, bw_user_basic.modified,
+#     bw_user_access.last_access, organizations.created_date) take the run's
+#     wall clock; every value the seeder writes explicitly is deterministic.
 # =============================================================================
 use strict;
 use warnings;
@@ -82,11 +82,22 @@ die "FATAL: MariaDB ENCRYPT() returned NULL — DES crypt unavailable in the db 
     unless defined $pw_hash && length($pw_hash) == 13;
 print "password hash for '$TEST_PASSWORD': $pw_hash\n";
 
+# ---------------------------------------------------------------- constants
+# uid 1 = "root": generic admin account name that matches the hardcoded admin
+# list in Bawi::Auth::is_admin, so admin paths are testable. Not a real person.
+my $N_USERS = 50;   # <= 99: 'testuserNN' must fit the app's char(10)/varchar(10) id columns
+# Guards live BEFORE the wipe so a bad edit dies without emptying the DB.
+die "N_USERS must be <= 99 ('testuser100' would overflow 10-char id columns)\n" if $N_USERS > 99;
+# Floor: registers (uids 46..50), degrees (2..46), careers (2..25) and other
+# blocks hardcode uid ranges; a smaller pool would seed orphan references.
+die "N_USERS must be >= 50 (later blocks hardcode uid ranges up to 50)\n" if $N_USERS < 50;
+
 # ------------------------------------------------------------------- wipe
 # Truncate every base table except the migration ledger, so "wipe + reseed"
 # is true by construction — a hand-kept list drifts as migrations add tables
 # (and already had: UI-writable tables were missing). No migration seeds
-# reference rows, so truncate-all is safe.
+# reference rows, so truncate-all is safe (a rule stated in the migration
+# runner's CONTRACT header: reference rows belong here, not in migrations).
 my $tables = $dbh->selectcol_arrayref(q{
     SELECT table_name FROM information_schema.tables
     WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'
@@ -95,13 +106,6 @@ print "truncating ", scalar(@$tables), " tables ...\n";
 $dbh->do("TRUNCATE TABLE `$_`") for @$tables;
 
 # ------------------------------------------------------------------ users
-# uid 1 = "root": generic admin account name that matches the hardcoded admin
-# list in Bawi::Auth::is_admin, so admin paths are testable. Not a real person.
-my $N_USERS = 50;   # <= 99: 'testuserNN' must fit the app's char(10)/varchar(10) id columns
-die "N_USERS must be <= 99 ('testuser100' would overflow 10-char id columns)\n" if $N_USERS > 99;
-# Floor: registers (uids 46..50), degrees (2..46), careers (2..25) and other
-# blocks hardcode uid ranges; a smaller pool would seed orphan references.
-die "N_USERS must be >= 50 (later blocks hardcode uid ranges up to 50)\n" if $N_USERS < 50;
 print "seeding $N_USERS users (ids: root, testuser02..testuser$N_USERS; password: $TEST_PASSWORD)\n";
 my %uname;   # uid -> display name
 my %uid2id;  # uid -> login id
@@ -488,13 +492,17 @@ print "seeding career entries (organizations / org_alias / bw_user_career)\n";
     my $org = $dbh->prepare(q{
         INSERT INTO organizations (org_id, name, created_by) VALUES (?,?,1)});
     my $al  = $dbh->prepare(q{INSERT INTO org_alias (alias, org_id) VALUES (?,?)});
-    # App invariant (Bawi::User::add_org): the canonical name is ALWAYS also
-    # an alias — "no alias == invisible org". Keep each name in its list.
+    # App invariant (Bawi::User::resolve_or_create_org): the canonical name
+    # is ALWAYS also an alias — "no alias == invisible org". Keep each name
+    # in its list. Names are stored HTML-ESCAPED (house style; org_suggest
+    # escapes the query before matching) — org 5 carries a literal & as
+    # &amp; to keep that storage class exercised.
     my @ORGS = (        # org_id, canonical name, searchable aliases
         [1, '가상연구소 (Synthetic Labs)', ['가상연구소 (Synthetic Labs)', '가상연구소', 'Synthetic Labs']],
         [2, 'Example Corp',                ['Example Corp', '예제회사']],
         [3, '모의대학병원',                ['모의대학병원']],
         [4, 'Test Foundation',             ['Test Foundation', '테스트재단']],
+        [5, 'Example &amp; Sons',          ['Example &amp; Sons', '예제앤선즈']],
     );
     for my $o (@ORGS) {
         my ($oid, $oname, $aliases) = @$o;
@@ -511,7 +519,7 @@ print "seeding career entries (organizations / org_alias / bw_user_career)\n";
         $cid++;
         my $start   = BASE_EPOCH - 86400 * 365 * (6 - $uid % 5);
         my $ongoing = $uid % 4 == 0;     # NULL end_date = ongoing
-        $cr->execute($cid, $uid, $ctypes[$uid % 6], 1 + ($uid % 4),
+        $cr->execute($cid, $uid, $ctypes[$uid % 6], 1 + ($uid % 5),
                      '합성 직위 (synthetic position)',
                      d($start), $ongoing ? undef : d($start + 86400 * 365 * 2));
     }

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -6,9 +6,9 @@
 # no real users, no PII, no production content. Every name/id/email/phone is
 # a labeled synthetic value (testerNN, @example.invalid, 010-0000-xxxx).
 #
-# Deterministic: uses a private LCG (seeded below), so two runs produce
-# byte-identical data on any platform. Re-running truncates and reseeds the
-# tables it owns (idempotent).
+# Deterministic: every varied value is derived arithmetically from row ids,
+# so two runs produce byte-identical data on any platform. Re-running
+# truncates and reseeds (idempotent).
 #
 # Run inside the web container (which has DBI + DBD::mysql):
 #   docker compose exec web perl /home/bawi/bawi-spring/seed/seed.pl
@@ -72,12 +72,6 @@ for my $try (1 .. 90) {
 }
 die "cannot connect to $name\@$host after 90s: $@" unless $dbh;
 $dbh->do("SET NAMES utf8mb4");
-
-# ------------------------------------------------------------- determinism
-# Private LCG so output is identical across perl versions/platforms.
-my $lcg_state = 20260706;
-sub prng { $lcg_state = ($lcg_state * 1103515245 + 12345) % 2147483648; return $lcg_state }
-sub pick { my $n = shift; return prng() % $n }
 
 # Deterministic clock: everything is derived from this fixed base (UTC).
 use constant BASE_EPOCH => 1735689600;      # 2025-01-01 00:00:00 UTC
@@ -250,7 +244,7 @@ my @article_rows;            # [article_id, board_id, article_no, uid, created_e
             my $category = ($kw eq 'free' && $no >= 20 && $no <= 24) ? 1 : 0;
             $h->execute($article_id, $no, $parent_no, $thread_no, $bid, $category,
                         $title, $author, $uid2id{$author}, $uname{$author},
-                        pick(200), $has_poll, dt($created));
+                        ($article_id * 37) % 200, $has_poll, dt($created));
             my $body = $category
                 ? join("\n",
                     "## 마크다운 테스트 글 $no (markdown test)",

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -57,9 +57,18 @@ my $name = $ENV{BAWI_DB_NAME} || 'bawi';
 my $user = $ENV{BAWI_DB_USER} || 'bawi_test';
 my $pass = $ENV{BAWI_DB_PASS} || 'bawi-local-test-pw';
 
-my $dbh = DBI->connect("dbi:mysql:database=$name;host=$host", $user, $pass,
-                       { RaiseError => 1, PrintError => 0 })
-    or die "cannot connect to $name\@$host: $DBI::errstr\n";
+# Bounded connect-retry: on a first boot the DB container may still be
+# loading the schema; it only answers over the network after init (schema +
+# migrations) is complete, so "connects" == "ready to seed".
+my $dbh;
+for my $try (1 .. 90) {
+    $dbh = eval { DBI->connect("dbi:mysql:database=$name;host=$host", $user, $pass,
+                               { RaiseError => 1, PrintError => 0 }) };
+    last if $dbh;
+    print "waiting for the DB at $host ($try s) ...\n" if $try == 1 || $try % 15 == 0;
+    sleep 1;
+}
+die "cannot connect to $name\@$host after 90s: $@" unless $dbh;
 $dbh->do("SET NAMES utf8mb4");
 
 # ------------------------------------------------------------- determinism
@@ -96,8 +105,8 @@ die "N_USERS must be >= 50 (later blocks hardcode uid ranges up to 50)\n" if $N_
 # Truncate every base table except the migration ledger, so "wipe + reseed"
 # is true by construction — a hand-kept list drifts as migrations add tables
 # (and already had: UI-writable tables were missing). No migration seeds
-# reference rows, so truncate-all is safe (a rule stated in the migration
-# runner's CONTRACT header: reference rows belong here, not in migrations).
+# reference rows, so truncate-all is safe (per the migration runner's
+# CONTRACT header: rows a migration ships for prod must be mirrored here).
 my $tables = $dbh->selectcol_arrayref(q{
     SELECT table_name FROM information_schema.tables
     WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -22,18 +22,24 @@
 #   SEEDED: bw_xauth_passwd (50 users, all password "test1234"),
 #     bw_user_ki, bw_user_basic, bw_user_sig, bw_user_access,
 #     bw_group (3), bw_group_user, bw_xboard_board (6),
-#     bw_xboard_header/body (320 articles), bw_xboard_comment (320),
+#     bw_xboard_header/body (320 articles; 5 are category=1 markdown, to
+#     exercise Bawi::Markdown + the bw_xboard_body_html render cache),
+#     bw_xboard_comment (320),
 #     bw_xboard_notice, bw_xboard_recom, bw_xboard_bookmark, bw_note (40),
 #     bw_xboard_poll/_opt/_ans (2 article polls), bw_xpoll/_question/_choice
 #     (1 survey), countries, schools, majors, circles, registers,
-#     bw_data_major, bw_user_major, bw_user_degree, bw_user_circle, loads,
+#     bw_data_major, bw_user_major, bw_user_degree, bw_user_circle,
+#     organizations, org_alias, bw_user_career (career v3.2), loads,
 #     bw_xboard_stat_board/_article/_user (aggregated from the seed).
 #   EMPTY (documented): bw_xboard_attach (no files on disk), bw_xboard_scrap,
 #     bw_xboard_tag, bw_xboard_tagmap, bw_xboard_commentref, bw_xauth_session
-#     (created at login), bw_xauth_new_passwd, bw_user_photo, bw_user_gbook,
-#     bw_user_support, bw_symp, bw_user_access_history, bawi_access_stat,
-#     bw_note_notify_boxcar, bw_postman_log, bw_poll* (legacy), bw_xpoll_check,
-#     notes (legacy).
+#     (created at login), bw_xboard_body_html (read-through render cache,
+#     self-populating on first view), bw_xauth_new_passwd, bw_user_photo,
+#     bw_user_gbook, bw_user_support, bw_symp, bw_user_access_history,
+#     bawi_access_stat, bw_note_notify_boxcar, bw_postman_log,
+#     bw_poll* (legacy), bw_xpoll_check, notes (legacy).
+#     User-writable empties are still truncated on reseed (see @owned_tables)
+#     so UI experiments don't survive a "wipe + reseed".
 # =============================================================================
 use strict;
 use warnings;
@@ -77,11 +83,14 @@ my @owned_tables = qw(
     bw_group bw_group_user
     bw_xboard_board bw_xboard_header bw_xboard_body bw_xboard_comment
     bw_xboard_notice bw_xboard_recom bw_xboard_bookmark
+    bw_xboard_scrap bw_xboard_attach bw_xboard_commentref
+    bw_xboard_tag bw_xboard_tagmap bw_xboard_body_html
     bw_note
     bw_xboard_poll bw_xboard_poll_opt bw_xboard_poll_ans
     bw_xpoll bw_xpoll_question bw_xpoll_choice
     countries schools majors circles registers
     bw_data_major bw_user_major bw_user_degree bw_user_circle
+    organizations org_alias bw_user_career
     loads
     bw_xboard_stat_board bw_xboard_stat_article bw_xboard_stat_user
     bw_xauth_session
@@ -92,7 +101,8 @@ $dbh->do("TRUNCATE TABLE $_") for @owned_tables;
 # ------------------------------------------------------------------ users
 # uid 1 = "root": generic admin account name that matches the hardcoded admin
 # list in Bawi::Auth::is_admin, so admin paths are testable. Not a real person.
-my $N_USERS = 50;
+my $N_USERS = 50;   # <= 99: 'testuserNN' must fit the app's char(10)/varchar(10) id columns
+die "N_USERS must be <= 99 ('testuser100' would overflow 10-char id columns)\n" if $N_USERS > 99;
 print "seeding $N_USERS users (ids: root, testuser02..testuser$N_USERS; password: $TEST_PASSWORD)\n";
 my %uname;   # uid -> display name
 my %uid2id;  # uid -> login id
@@ -184,7 +194,7 @@ my @article_rows;            # [article_id, board_id, article_no, uid, created_e
             (article_id, article_no, parent_no, thread_no, board_id, category,
              title, uid, id, name, count, recom, scrap, comments,
              has_attach, has_poll, created)
-        VALUES (?,?,?,?,?,0,?,?,?,?,?,0,0,0,0,?,?)});
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,0,0,0,0,?,?)});
     my $bo = $dbh->prepare(q{
         INSERT INTO bw_xboard_body (article_id, board_id, body) VALUES (?,?,?)});
 
@@ -205,26 +215,48 @@ my @article_rows;            # [article_id, board_id, article_no, uid, created_e
             }
             my $title = $parent_no
                 ? sprintf('Re: [테스트] %s 글 %03d', $btitle, $parent_no)
-                : sprintf('[테스트] %s 글 %03d — synthetic article', $btitle, $no);
-            $title = substr($title, 0, 64);
+                : sprintf('[테스트] %s 글 %03d — synthetic', $btitle, $no);
+            # bw_xboard_header.title is char(64); this script has no `use utf8`,
+            # so length() counts BYTES — a blind substr could cut mid-Hangul.
+            # Titles are ours and deterministic: fail loudly instead.
+            die "seed bug: title exceeds 64 bytes (shorten the board title in \@BOARDS): $title\n"
+                if length($title) > 64;
             my $has_poll = 0;
             if (($kw eq 'free' && $no == 10) || ($kw eq 'career' && $no == 5)) {
                 $has_poll = 1;
                 $poll_articles{$article_id} = $bid;
             }
-            $h->execute($article_id, $no, $parent_no, $thread_no, $bid,
+            # 5 markdown articles: category=1 routes reads through
+            # Bawi::Markdown::render + the bw_xboard_body_html cache
+            # (lib/Bawi/Board.pm format_article), the newest read path.
+            my $category = ($kw eq 'free' && $no >= 20 && $no <= 24) ? 1 : 0;
+            $h->execute($article_id, $no, $parent_no, $thread_no, $bid, $category,
                         $title, $author, $uid2id{$author}, $uname{$author},
                         pick(200), $has_poll, dt($created));
-            my $body = join("\n",
-                "이 글은 테스트 환경용 합성 데이터입니다. (SYNTHETIC TEST DATA)",
-                "게시판: $btitle / 글 번호: $no / article_id: $article_id",
-                "작성자: $uname{$author} ($uid2id{$author}) — 실존 인물이 아닙니다.",
-                "",
-                "본문 채움 문단입니다. 페이지네이션과 목록/읽기 화면을 시험하기 위한",
-                "내용이며 실제 서비스 데이터와 무관합니다. " . ('테스트 문장입니다. ' x (1 + $no % 5)),
-                "",
-                "Filler paragraph #$no for list/read/pagination testing.",
-            );
+            my $body = $category
+                ? join("\n",
+                    "## 마크다운 테스트 글 $no (markdown test)",
+                    "",
+                    "이 글은 **category=1** 로 저장되어 읽기 시점에 Bawi::Markdown 으로",
+                    "렌더링되고, 결과가 `bw_xboard_body_html` 캐시에 기록됩니다.",
+                    "",
+                    "- 목록 항목 하나",
+                    "- 목록 항목 둘 — [링크](https://example.invalid/md-$no)",
+                    "",
+                    "```perl",
+                    "print \"fenced code block #$no\\n\";",
+                    "```",
+                  )
+                : join("\n",
+                    "이 글은 테스트 환경용 합성 데이터입니다. (SYNTHETIC TEST DATA)",
+                    "게시판: $btitle / 글 번호: $no / article_id: $article_id",
+                    "작성자: $uname{$author} ($uid2id{$author}) — 실존 인물이 아닙니다.",
+                    "",
+                    "본문 채움 문단입니다. 페이지네이션과 목록/읽기 화면을 시험하기 위한",
+                    "내용이며 실제 서비스 데이터와 무관합니다. " . ('테스트 문장입니다. ' x (1 + $no % 5)),
+                    "",
+                    "Filler paragraph #$no for list/read/pagination testing.",
+                  );
             $bo->execute($article_id, $bid, $body);
             $first_article_id{$bid} = $article_id if $no == 1;
             push @article_rows, [$article_id, $bid, $no, $author, $created];
@@ -289,9 +321,10 @@ print "seeding notices + bookmarks\n";
         my $seq = 0;
         for my $bid (1, 2, 3, 4, 6) {
             # last-read position a bit behind the tip -> "new article" markers
-            my ($max_no) = grep { $_->[0] == $bid } @BOARDS;
-            my $behind = 3 + ($uid % 4);
-            my $article_no = $max_no->[5] > $behind ? $max_no->[5] - $behind : 0;
+            my ($board) = grep { $_->[0] == $bid } @BOARDS;
+            my $max_no  = $board->[5];             # articles column of @BOARDS
+            my $behind  = 3 + ($uid % 4);
+            my $article_no = $max_no > $behind ? $max_no - $behind : 0;
             $bm->execute($uid, $bid, $article_no, 0, ++$seq);
         }
     }
@@ -447,6 +480,39 @@ print "seeding degrees / majors / circles per user\n";
     $uc->execute($_, 1 + ($_ % 4)) for 2 .. 20;
 }
 
+# ------------------------------------------------------------ career (v3.2)
+print "seeding career entries (organizations / org_alias / bw_user_career)\n";
+{
+    my $org = $dbh->prepare(q{
+        INSERT INTO organizations (org_id, name, created_by) VALUES (?,?,1)});
+    my $al  = $dbh->prepare(q{INSERT INTO org_alias (alias, org_id) VALUES (?,?)});
+    my @ORGS = (        # org_id, canonical name, searchable aliases
+        [1, '가상연구소 (Synthetic Labs)', ['가상연구소', 'Synthetic Labs']],
+        [2, 'Example Corp',                ['Example Corp', '예제회사']],
+        [3, '모의대학병원',                ['모의대학병원']],
+        [4, 'Test Foundation',             ['Test Foundation', '테스트재단']],
+    );
+    for my $o (@ORGS) {
+        my ($oid, $oname, $aliases) = @$o;
+        $org->execute($oid, $oname);
+        $al->execute($_, $oid) for @$aliases;
+    }
+    my @ctypes = ('employment','internship','volunteer','research','military','other');
+    my $cr = $dbh->prepare(q{
+        INSERT INTO bw_user_career
+            (career_id, uid, type, organization_id, position, start_date, end_date)
+        VALUES (?,?,?,?,?,?,?)});
+    my $cid = 0;
+    for my $uid (2 .. 25) {              # 24 entries; full type-enum coverage
+        $cid++;
+        my $start   = BASE_EPOCH - 86400 * 365 * (6 - $uid % 5);
+        my $ongoing = $uid % 4 == 0;     # NULL end_date = ongoing
+        $cr->execute($cid, $uid, $ctypes[$uid % 6], 1 + ($uid % 4),
+                     '합성 직위 (synthetic position)',
+                     d($start), $ongoing ? undef : d($start + 86400 * 365 * 2));
+    }
+}
+
 # ------------------------------------------------------------------- loads
 {
     my $ld = $dbh->prepare(q{
@@ -481,7 +547,7 @@ $dbh->do(q{INSERT INTO bw_xboard_stat_article
            FROM bw_xboard_header h LEFT JOIN bw_user_ki k ON k.uid = h.uid
            ORDER BY h.recom DESC, h.article_id LIMIT 30});
 $dbh->do(q{INSERT INTO bw_xboard_stat_user (id, name, articles, counts, comments, recoms)
-           SELECT h.id, h.name, COUNT(*), SUM(h.count), 0, SUM(h.recom)
+           SELECT h.id, h.name, COUNT(*), SUM(h.count), SUM(h.comments), SUM(h.recom)
            FROM bw_xboard_header h GROUP BY h.id, h.name});
 
 # -------------------------------------------------------------- verification
@@ -489,7 +555,8 @@ print "\n=== verification ===\n";
 for my $t (qw(bw_xauth_passwd bw_user_ki bw_group bw_group_user bw_xboard_board
               bw_xboard_header bw_xboard_body bw_xboard_comment bw_xboard_recom
               bw_xboard_notice bw_xboard_bookmark bw_note bw_xboard_poll
-              bw_xboard_poll_opt bw_xboard_poll_ans bw_user_degree registers)) {
+              bw_xboard_poll_opt bw_xboard_poll_ans bw_user_degree registers
+              organizations org_alias bw_user_career)) {
     my ($n) = $dbh->selectrow_array("SELECT COUNT(*) FROM $t");
     printf "  %-22s %6d rows\n", $t, $n;
 }

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -1,0 +1,510 @@
+#!/usr/bin/perl
+# =============================================================================
+# seed.pl — deterministic SYNTHETIC data seeder for the bawi test database
+# =============================================================================
+# Fills the structure-only test schema with clean, obviously-fake data:
+# no real users, no PII, no production content. Every name/id/email/phone is
+# a labeled synthetic value (testuserNN, @example.invalid, 010-0000-xxxx).
+#
+# Deterministic: uses a private LCG (seeded below), so two runs produce
+# byte-identical data on any platform. Re-running truncates and reseeds the
+# tables it owns (idempotent).
+#
+# Run inside the web container (which has DBI + DBD::mysql):
+#   docker compose exec web perl /home/bawi/bawi-spring/seed/seed.pl
+#
+# Connection comes from BAWI_DB_{HOST,NAME,USER,PASS} (set in
+# docker-compose.yml), falling back to the compose defaults.
+#
+# What gets seeded / what stays empty: see the table at the bottom of this
+# header.
+#
+#   SEEDED: bw_xauth_passwd (50 users, all password "test1234"),
+#     bw_user_ki, bw_user_basic, bw_user_sig, bw_user_access,
+#     bw_group (3), bw_group_user, bw_xboard_board (6),
+#     bw_xboard_header/body (320 articles), bw_xboard_comment (320),
+#     bw_xboard_notice, bw_xboard_recom, bw_xboard_bookmark, bw_note (40),
+#     bw_xboard_poll/_opt/_ans (2 article polls), bw_xpoll/_question/_choice
+#     (1 survey), countries, schools, majors, circles, registers,
+#     bw_data_major, bw_user_major, bw_user_degree, bw_user_circle, loads,
+#     bw_xboard_stat_board/_article/_user (aggregated from the seed).
+#   EMPTY (documented): bw_xboard_attach (no files on disk), bw_xboard_scrap,
+#     bw_xboard_tag, bw_xboard_tagmap, bw_xboard_commentref, bw_xauth_session
+#     (created at login), bw_xauth_new_passwd, bw_user_photo, bw_user_gbook,
+#     bw_user_support, bw_symp, bw_user_access_history, bawi_access_stat,
+#     bw_note_notify_boxcar, bw_postman_log, bw_poll* (legacy), bw_xpoll_check,
+#     notes (legacy).
+# =============================================================================
+use strict;
+use warnings;
+use DBI;
+use POSIX qw(strftime);
+
+# ---------------------------------------------------------------- connection
+my $host = $ENV{BAWI_DB_HOST} || 'db';
+my $name = $ENV{BAWI_DB_NAME} || 'bawi';
+my $user = $ENV{BAWI_DB_USER} || 'bawi_test';
+my $pass = $ENV{BAWI_DB_PASS} || 'bawi-local-test-pw';
+
+my $dbh = DBI->connect("dbi:mysql:database=$name;host=$host", $user, $pass,
+                       { RaiseError => 1, PrintError => 0 })
+    or die "cannot connect to $name\@$host: $DBI::errstr\n";
+$dbh->do("SET NAMES utf8mb4");
+
+# ------------------------------------------------------------- determinism
+# Private LCG so output is identical across perl versions/platforms.
+my $lcg_state = 20260706;
+sub prng { $lcg_state = ($lcg_state * 1103515245 + 12345) % 2147483648; return $lcg_state }
+sub pick { my $n = shift; return prng() % $n }
+
+# Deterministic clock: everything is derived from this fixed base (UTC).
+use constant BASE_EPOCH => 1735689600;      # 2025-01-01 00:00:00 UTC
+sub dt { my $epoch = shift; return strftime('%Y-%m-%d %H:%M:%S', gmtime($epoch)) }
+sub d  { my $epoch = shift; return strftime('%Y-%m-%d', gmtime($epoch)) }
+
+# ------------------------------------------------------- password (DES crypt)
+# The app authenticates with  passwd = ENCRYPT(?, passwd)  server-side, so
+# server-side DES crypt MUST work. Fail loudly here rather than at login time.
+my $TEST_PASSWORD = 'test1234';   # (DES crypt only uses the first 8 chars)
+my ($pw_hash) = $dbh->selectrow_array(q{SELECT ENCRYPT(?, 'bw')}, undef, $TEST_PASSWORD);
+die "FATAL: MariaDB ENCRYPT() returned NULL — DES crypt unavailable in the db container; logins would be impossible\n"
+    unless defined $pw_hash && length($pw_hash) == 13;
+print "password hash for '$TEST_PASSWORD': $pw_hash\n";
+
+# ------------------------------------------------------------------- wipe
+my @owned_tables = qw(
+    bw_xauth_passwd bw_user_ki bw_user_basic bw_user_sig bw_user_access
+    bw_group bw_group_user
+    bw_xboard_board bw_xboard_header bw_xboard_body bw_xboard_comment
+    bw_xboard_notice bw_xboard_recom bw_xboard_bookmark
+    bw_note
+    bw_xboard_poll bw_xboard_poll_opt bw_xboard_poll_ans
+    bw_xpoll bw_xpoll_question bw_xpoll_choice
+    countries schools majors circles registers
+    bw_data_major bw_user_major bw_user_degree bw_user_circle
+    loads
+    bw_xboard_stat_board bw_xboard_stat_article bw_xboard_stat_user
+    bw_xauth_session
+);
+print "truncating ", scalar(@owned_tables), " tables ...\n";
+$dbh->do("TRUNCATE TABLE $_") for @owned_tables;
+
+# ------------------------------------------------------------------ users
+# uid 1 = "root": generic admin account name that matches the hardcoded admin
+# list in Bawi::Auth::is_admin, so admin paths are testable. Not a real person.
+my $N_USERS = 50;
+print "seeding $N_USERS users (ids: root, testuser02..testuser$N_USERS; password: $TEST_PASSWORD)\n";
+my %uname;   # uid -> display name
+my %uid2id;  # uid -> login id
+{
+    my $sth = $dbh->prepare(q{
+        INSERT INTO bw_xauth_passwd (uid, id, name, passwd, email, modified, accessed, access)
+        VALUES (?,?,?,?,?,?,?,?)});
+    my $ki  = $dbh->prepare(q{INSERT INTO bw_user_ki (uid, ki) VALUES (?,?)});
+    my $bas = $dbh->prepare(q{
+        INSERT INTO bw_user_basic (uid, ename, mobile_tel, birth, affiliation, title, greeting)
+        VALUES (?,?,?,?,?,?,?)});
+    my $acc = $dbh->prepare(q{INSERT INTO bw_user_access (uid, id, count) VALUES (?,?,?)});
+
+    for my $uid (1 .. $N_USERS) {
+        my ($id, $nm);
+        if ($uid == 1) { ($id, $nm) = ('root', '관리자테스트') }
+        else           { $id = sprintf('testuser%02d', $uid); $nm = sprintf('테스트유저%02d', $uid) }
+        $uid2id{$uid} = $id;
+        $uname{$uid}  = $nm;
+        my $modified = dt(BASE_EPOCH + 86400 * (300 + $uid));       # recent-ish
+        my $accessed = dt(BASE_EPOCH + 86400 * 500 + 3600 * $uid);
+        $sth->execute($uid, $id, $nm, $pw_hash, "$id\@example.invalid",
+                      $modified, $accessed, 100 + $uid * 3);
+        $ki->execute($uid, $uid == 1 ? 1 : 10 + ($uid % 25));
+        $bas->execute($uid, sprintf('Test User %02d', $uid),
+                      sprintf('010-0000-%04d', $uid),
+                      d(BASE_EPOCH - 86400 * 365 * (25 + $uid % 20)),
+                      sprintf('가상연구소 %02d', 1 + $uid % 7),
+                      '테스트직함',
+                      "합성 테스트 계정입니다 (synthetic test account #$uid).",
+        );
+        $acc->execute($uid, $id, 10 + $uid);
+    }
+    my $sig = $dbh->prepare(q{INSERT INTO bw_user_sig (uid, sig) VALUES (?,?)});
+    $sig->execute($_, "-- 테스트 서명 $_ (synthetic signature)") for 2 .. 10;
+}
+
+# ----------------------------------------------------------------- groups
+print "seeding 3 groups + memberships\n";
+{
+    my $g = $dbh->prepare(q{
+        INSERT INTO bw_group (gid, pgid, title, keyword, uid, type, seq, created,
+                              g_sub, m_sub, a_sub, g_board, m_board, a_board)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)});
+    $g->execute(1, 0, '바위 테스트',   'bawitest',   1, 'open',   1, dt(BASE_EPOCH), 1,1,0,1,1,0);
+    $g->execute(2, 1, '동호회 테스트', 'clubtest',   1, 'open',   2, dt(BASE_EPOCH), 1,1,0,1,1,0);
+    $g->execute(3, 1, '비공개 테스트', 'closedtest', 1, 'closed', 3, dt(BASE_EPOCH), 0,1,0,0,1,0);
+
+    my $gu = $dbh->prepare(q{
+        INSERT INTO bw_group_user (gid, uid, status, created) VALUES (?,?,'active',?)});
+    $gu->execute(1, $_, dt(BASE_EPOCH + 3600 * $_)) for 1 .. $N_USERS;
+    $gu->execute(2, $_, dt(BASE_EPOCH + 7200 * $_)) for 2 .. 21;
+    $gu->execute(3, $_, dt(BASE_EPOCH + 9600 * $_)) for 2 .. 6;
+}
+
+# ----------------------------------------------------------------- boards
+#  id keyword  gid title                 anon-read  articles
+my @BOARDS = (
+    [1, 'notice', 1, '공지사항 테스트',   1,  15],
+    [2, 'free',   1, '자유게시판 테스트', 0, 150],
+    [3, 'qna',    1, '질문답변 테스트',   0,  60],
+    [4, 'career', 1, '진로 테스트',       0,  45],
+    [5, 'photo',  1, '사진 테스트',       0,  25],
+    [6, 'club',   2, '동호회 테스트판',   0,  25],
+);
+print "seeding ", scalar(@BOARDS), " boards\n";
+{
+    my $b = $dbh->prepare(q{
+        INSERT INTO bw_xboard_board
+            (board_id, keyword, gid, title, uid, id, name, skin, seq, created,
+             is_imgboard, a_read, a_write, a_comment)
+        VALUES (?,?,?,?,?,?,?,'default',?,?,?,?,0,0)});
+    for my $bd (@BOARDS) {
+        my ($bid, $kw, $gid, $title, $anon, $n) = @$bd;
+        $b->execute($bid, $kw, $gid, $title, 1, 'root', $uname{1},
+                    $bid, dt(BASE_EPOCH + 86400 * $bid), ($kw eq 'photo' ? 1 : 0), $anon);
+    }
+}
+
+# --------------------------------------------------------------- articles
+print "seeding articles (headers + bodies) ...\n";
+my $article_id = 0;
+my %first_article_id;        # board_id -> article_id of article_no 1
+my %poll_articles;           # article_id -> board_id (articles that get a poll)
+my @article_rows;            # [article_id, board_id, article_no, uid, created_epoch]
+{
+    my $h = $dbh->prepare(q{
+        INSERT INTO bw_xboard_header
+            (article_id, article_no, parent_no, thread_no, board_id, category,
+             title, uid, id, name, count, recom, scrap, comments,
+             has_attach, has_poll, created)
+        VALUES (?,?,?,?,?,0,?,?,?,?,?,0,0,0,0,?,?)});
+    my $bo = $dbh->prepare(q{
+        INSERT INTO bw_xboard_body (article_id, board_id, body) VALUES (?,?,?)});
+
+    for my $bd (@BOARDS) {
+        my ($bid, $kw, $gid, $btitle, $anon, $n) = @$bd;
+        my @thread;                       # per-board stack of recent top-levels
+        for my $no (1 .. $n) {
+            $article_id++;
+            my $author  = 2 + (($article_id * 7) % ($N_USERS - 1));   # uid 2..50
+            my $created = BASE_EPOCH + 86400 * 30 + $article_id * 3600 * 7;
+            my ($parent_no, $thread_no) = (0, $no);
+            if ($no > 1 && ($no % 4 == 0) && @thread) {               # every 4th: a reply
+                my $p = $thread[-1];
+                ($parent_no, $thread_no) = ($p->[0], $p->[1]);
+            } else {
+                push @thread, [$no, $no];
+                shift @thread while @thread > 3;
+            }
+            my $title = $parent_no
+                ? sprintf('Re: [테스트] %s 글 %03d', $btitle, $parent_no)
+                : sprintf('[테스트] %s 글 %03d — synthetic article', $btitle, $no);
+            $title = substr($title, 0, 64);
+            my $has_poll = 0;
+            if (($kw eq 'free' && $no == 10) || ($kw eq 'career' && $no == 5)) {
+                $has_poll = 1;
+                $poll_articles{$article_id} = $bid;
+            }
+            $h->execute($article_id, $no, $parent_no, $thread_no, $bid,
+                        $title, $author, $uid2id{$author}, $uname{$author},
+                        pick(200), $has_poll, dt($created));
+            my $body = join("\n",
+                "이 글은 테스트 환경용 합성 데이터입니다. (SYNTHETIC TEST DATA)",
+                "게시판: $btitle / 글 번호: $no / article_id: $article_id",
+                "작성자: $uname{$author} ($uid2id{$author}) — 실존 인물이 아닙니다.",
+                "",
+                "본문 채움 문단입니다. 페이지네이션과 목록/읽기 화면을 시험하기 위한",
+                "내용이며 실제 서비스 데이터와 무관합니다. " . ('테스트 문장입니다. ' x (1 + $no % 5)),
+                "",
+                "Filler paragraph #$no for list/read/pagination testing.",
+            );
+            $bo->execute($article_id, $bid, $body);
+            $first_article_id{$bid} = $article_id if $no == 1;
+            push @article_rows, [$article_id, $bid, $no, $author, $created];
+        }
+    }
+    print "  $article_id articles\n";
+}
+
+# --------------------------------------------------------------- comments
+print "seeding comments ...\n";
+{
+    my $c = $dbh->prepare(q{
+        INSERT INTO bw_xboard_comment
+            (comment_id, comment_no, board_id, article_id, body, uid, id, name, created)
+        VALUES (?,?,?,?,?,?,?,?,?)});
+    my $comment_id = 0;
+    my %board_comment_no;                 # per-board running comment_no
+    for my $ar (@article_rows) {
+        my ($aid, $bid, $no, $author, $created) = @$ar;
+        next if $aid % 2;                 # every 2nd article gets comments
+        my $n = 1 + ($aid % 4);           # 1..4 comments
+        for my $k (1 .. $n) {
+            $comment_id++;
+            my $cno = ++$board_comment_no{$bid};
+            my $cuid = 2 + (($aid * 3 + $k * 11) % ($N_USERS - 1));
+            $c->execute($comment_id, $cno, $bid, $aid,
+                        "테스트 댓글 $k (synthetic comment on article $aid)",
+                        $cuid, $uid2id{$cuid}, $uname{$cuid},
+                        dt($created + 600 * $k));
+        }
+    }
+    print "  $comment_id comments\n";
+}
+
+# ------------------------------------------------------- recommendations
+print "seeding recommendations ...\n";
+{
+    my $r = $dbh->prepare(q{
+        INSERT INTO bw_xboard_recom (uid, article_id, rectime) VALUES (?,?,?)});
+    my $n = 0;
+    for my $ar (@article_rows) {
+        my ($aid, $bid, $no, $author, $created) = @$ar;
+        my $k = $aid % 6;                 # 0..5 recommendations
+        for my $i (1 .. $k) {
+            $r->execute(1 + $i, $aid, dt($created + 3600 + 60 * $i));  # uids 2..6
+            $n++;
+        }
+    }
+    print "  $n recommendations\n";
+}
+
+# ------------------------------------------------------ notices, bookmarks
+print "seeding notices + bookmarks\n";
+{
+    my $nt = $dbh->prepare(q{INSERT INTO bw_xboard_notice (board_id, article_id) VALUES (?,?)});
+    $nt->execute($_->[0], $first_article_id{$_->[0]}) for @BOARDS;
+
+    my $bm = $dbh->prepare(q{
+        INSERT INTO bw_xboard_bookmark (uid, board_id, article_no, comment_no, seq)
+        VALUES (?,?,?,?,?)});
+    for my $uid (1 .. 10) {
+        my $seq = 0;
+        for my $bid (1, 2, 3, 4, 6) {
+            # last-read position a bit behind the tip -> "new article" markers
+            my ($max_no) = grep { $_->[0] == $bid } @BOARDS;
+            my $behind = 3 + ($uid % 4);
+            my $article_no = $max_no->[5] > $behind ? $max_no->[5] - $behind : 0;
+            $bm->execute($uid, $bid, $article_no, 0, ++$seq);
+        }
+    }
+}
+
+# ------------------------------------------------------------------ notes
+print "seeding 40 notes\n";
+{
+    my $n = $dbh->prepare(q{
+        INSERT INTO bw_note (msg_id, to_id, to_name, from_id, from_name, msg, sent_time, read_time)
+        VALUES (?,?,?,?,?,?,?,?)});
+    for my $i (0 .. 39) {
+        my $from = 1 + ($i % 10);
+        my $to   = 1 + (($i + 3) % 10);
+        my $sent = BASE_EPOCH + 86400 * 400 + $i * 10800;
+        $n->execute($i + 1,
+                    $uid2id{$to},   $uname{$to},
+                    $uid2id{$from}, $uname{$from},
+                    "합성 쪽지 #@{[$i+1]} 입니다. (synthetic note, not real correspondence)",
+                    dt($sent),
+                    ($i < 30 ? dt($sent + 3600) : undef));   # last 10 unread
+    }
+}
+
+# ------------------------------------------------------------ article polls
+print "seeding 2 article polls\n";
+{
+    my $p  = $dbh->prepare(q{
+        INSERT INTO bw_xboard_poll (poll_id, board_id, article_id, poll, created, closed)
+        VALUES (?,?,?,?,?,?)});
+    my $po = $dbh->prepare(q{
+        INSERT INTO bw_xboard_poll_opt (opt_id, poll_id, opt, count) VALUES (?,?,?,?)});
+    my $pa = $dbh->prepare(q{
+        INSERT INTO bw_xboard_poll_ans (poll_id, uid, opt_id) VALUES (?,?,?)});
+
+    my ($poll_id, $opt_id) = (0, 0);
+    for my $aid (sort { $a <=> $b } keys %poll_articles) {
+        $poll_id++;
+        my $bid = $poll_articles{$aid};
+        $p->execute($poll_id, $bid, $aid, "테스트 설문 $poll_id (synthetic poll)",
+                    dt(BASE_EPOCH + 86400 * 200), dt(BASE_EPOCH + 86400 * 900));
+        my @opts;
+        for my $o (1 .. 3) {
+            $opt_id++;
+            push @opts, $opt_id;
+            $po->execute($opt_id, $poll_id, "보기 $o (option $o)", 0);
+        }
+        for my $u (2 .. 13) {                       # 12 voters
+            my $choice = $opts[$u % 3];
+            $pa->execute($poll_id, $u, $choice);
+        }
+    }
+    $dbh->do(q{UPDATE bw_xboard_poll_opt o
+               SET count = (SELECT COUNT(*) FROM bw_xboard_poll_ans a
+                            WHERE a.opt_id = o.opt_id)});
+}
+
+# --------------------------------------------------------------- xpoll (survey)
+print "seeding 1 survey (bw_xpoll)\n";
+{
+    $dbh->do(q{INSERT INTO bw_xpoll
+        (poll_id, uid, name, id, dt_start, dt_end, opt_hide, numofq,
+         poll_title, poll_txt, lk, participant, poll_comment)
+        VALUES (1, 'root', ?, 'root', ?, ?, 0, 2,
+                '테스트 설문조사 (synthetic)', '테스트용 설문입니다.', 0, 12, '')},
+        undef, $uname{1}, d(BASE_EPOCH + 86400 * 380), d(BASE_EPOCH + 86400 * 900));
+    my $q = $dbh->prepare(q{
+        INSERT INTO bw_xpoll_question (question_id, question_txt, poll_id) VALUES (?,?,1)});
+    $q->execute(1, '테스트 질문 1 (synthetic question 1)');
+    $q->execute(2, '테스트 질문 2 (synthetic question 2)');
+    my $c = $dbh->prepare(q{
+        INSERT INTO bw_xpoll_choice (choice_id, question_id, choice_txt, choice_count, choice_q)
+        VALUES (?,?,?,?,?)});
+    my $cid = 0;
+    for my $qid (1, 2) {
+        for my $o (1 .. 3) {
+            $cid++;
+            $c->execute($cid, $qid, "선택지 $o (choice $o)", ($o == 1 ? 6 : ($o == 2 ? 4 : 2)), $qid);
+        }
+    }
+}
+
+# ------------------------------------------------- registration lookup data
+print "seeding registration lookups (countries/schools/majors/circles/registers)\n";
+{
+    my $co = $dbh->prepare(q{INSERT INTO countries (id, name, code) VALUES (?,?,?)});
+    $co->execute(1, '대한민국', 'KR');
+    $co->execute(2, 'United States', 'US');
+    $co->execute(3, 'Japan', 'JP');
+    $co->execute(4, 'Canada', 'CA');
+
+    my $sc = $dbh->prepare(q{
+        INSERT INTO schools (id, full_name, brief_name, url, country_code) VALUES (?,?,?,?,?)});
+    my @schools = (
+        [1, '가상대학교',            '가상대',    'https://example.invalid/u1', 'KR'],
+        [2, '모의과학기술원',        '모의과기원','https://example.invalid/u2', 'KR'],
+        [3, 'Example University',    'ExampleU',  'https://example.invalid/u3', 'US'],
+        [4, 'Sample Institute',      'SampleI',   'https://example.invalid/u4', 'US'],
+        [5, 'Synthetic College',     'SynthC',    'https://example.invalid/u5', 'CA'],
+        [6, 'テスト大学 (fictional)','テスト大',  'https://example.invalid/u6', 'JP'],
+    );
+    $sc->execute(@$_) for @schools;
+
+    my $mj = $dbh->prepare(q{INSERT INTO majors (id, parent_id, name) VALUES (?,?,?)});
+    my $dm = $dbh->prepare(q{INSERT INTO bw_data_major (major_id, parent_id, major) VALUES (?,?,?)});
+    my @majors = ([1,0,'자연과학'],[2,0,'공학'],[3,1,'수학'],[4,1,'물리학'],
+                  [5,1,'생물학'],[6,2,'전산학'],[7,2,'전자공학'],[8,2,'기계공학']);
+    for my $m (@majors) { $mj->execute(@$m); $dm->execute(@$m) }
+
+    my $ci = $dbh->prepare(q{INSERT INTO circles (id, name) VALUES (?,?)});
+    $ci->execute(1, '가상산악회'); $ci->execute(2, '모의사진반');
+    $ci->execute(3, '테스트합창단'); $ci->execute(4, '샘플바둑부');
+
+    # registers: fake alumni roster rows for exercising reg/register.cgi.
+    # pins are clearly fake (9xxxxxxx); rows 1-5 already linked to test uids.
+    my $rg = $dbh->prepare(q{
+        INSERT INTO registers (id, pin, ki, name, born_on, category, remarks, uid, member_status)
+        VALUES (?,?,?,?,?,'졸업','synthetic',?,?)});
+    for my $i (1 .. 30) {
+        my $uid = $i <= 5 ? 45 + $i : undef;
+        $rg->execute($i, 90000000 + $i, 10 + ($i % 25),
+                     sprintf('가상졸업생%02d', $i),
+                     d(BASE_EPOCH - 86400 * 365 * (30 + $i % 15)),
+                     $uid, ($uid ? '정' : ''));
+    }
+}
+
+# ------------------------------------------ career-adjacent user profile data
+print "seeding degrees / majors / circles per user\n";
+{
+    my @types = ('Bachelor','Master','Doctor','Postdoc','Resident','Fellow');
+    my $dg = $dbh->prepare(q{
+        INSERT INTO bw_user_degree
+            (degree_id, uid, type, school_id, department, advisors, content,
+             start_date, end_date, status)
+        VALUES (?,?,?,?,?,?,?,?,?,?)});
+    my $did = 0;
+    for my $uid (2 .. 46) {
+        $did++;
+        my $type    = $types[$uid % 6];             # exercises full career enum
+        my $start   = BASE_EPOCH - 86400 * 365 * (10 - $uid % 8);
+        my $current = $uid % 3 == 0;
+        $dg->execute($did, $uid, $type, 1 + ($uid % 6),
+                     '가상학과 (synthetic dept)', 'Prof. Placeholder',
+                     'synthetic degree record for career-feature testing',
+                     d($start),
+                     $current ? '1001-01-01' : d($start + 86400 * 365 * 4),
+                     $current ? 'current' : 'completed');
+    }
+    my $um = $dbh->prepare(q{INSERT INTO bw_user_major (uid, major_id) VALUES (?,?)});
+    $um->execute($_, 3 + ($_ % 6)) for 2 .. 41;     # child majors 3..8
+    my $uc = $dbh->prepare(q{INSERT INTO bw_user_circle (uid, circle_id) VALUES (?,?)});
+    $uc->execute($_, 1 + ($_ % 4)) for 2 .. 20;
+}
+
+# ------------------------------------------------------------------- loads
+{
+    my $ld = $dbh->prepare(q{
+        INSERT INTO loads (id, one, five, fifteen, online, created_at) VALUES (?,?,?,?,?,?)});
+    for my $i (1 .. 24) {
+        $ld->execute($i, 0.1 + 0.01 * ($i % 7), 0.2, 0.15, 3 + $i % 9,
+                     dt(BASE_EPOCH + 86400 * 500 + 3600 * $i));
+    }
+}
+
+# --------------------------------------- derived counters (kept consistent)
+print "updating derived counters (board/article aggregates, stat tables)\n";
+$dbh->do(q{UPDATE bw_xboard_header h
+           SET comments = (SELECT COUNT(*) FROM bw_xboard_comment c
+                           WHERE c.article_id = h.article_id)});
+$dbh->do(q{UPDATE bw_xboard_header h
+           SET recom = (SELECT COUNT(*) FROM bw_xboard_recom r
+                        WHERE r.article_id = h.article_id)});
+$dbh->do(q{UPDATE bw_xboard_board b SET
+           articles       = (SELECT COUNT(*)             FROM bw_xboard_header  h WHERE h.board_id = b.board_id),
+           max_article_no = (SELECT COALESCE(MAX(h.article_no),0) FROM bw_xboard_header  h WHERE h.board_id = b.board_id),
+           max_comment_no = (SELECT COALESCE(MAX(c.comment_no),0) FROM bw_xboard_comment c WHERE c.board_id = b.board_id)});
+
+# stat tables (hot/stat pages) aggregated from the seeded data
+$dbh->do(q{INSERT INTO bw_xboard_stat_board (board_id, counts, articles, comments, recoms)
+           SELECT board_id, SUM(count), COUNT(*), SUM(comments), SUM(recom)
+           FROM bw_xboard_header GROUP BY board_id});
+$dbh->do(q{INSERT INTO bw_xboard_stat_article
+               (board_id, article_id, title, id, name, count, recom, comments, created, ki)
+           SELECT h.board_id, h.article_id, h.title, h.id, h.name,
+                  h.count, h.recom, h.comments, h.created, COALESCE(k.ki, 0)
+           FROM bw_xboard_header h LEFT JOIN bw_user_ki k ON k.uid = h.uid
+           ORDER BY h.recom DESC, h.article_id LIMIT 30});
+$dbh->do(q{INSERT INTO bw_xboard_stat_user (id, name, articles, counts, comments, recoms)
+           SELECT h.id, h.name, COUNT(*), SUM(h.count), 0, SUM(h.recom)
+           FROM bw_xboard_header h GROUP BY h.id, h.name});
+
+# -------------------------------------------------------------- verification
+print "\n=== verification ===\n";
+for my $t (qw(bw_xauth_passwd bw_user_ki bw_group bw_group_user bw_xboard_board
+              bw_xboard_header bw_xboard_body bw_xboard_comment bw_xboard_recom
+              bw_xboard_notice bw_xboard_bookmark bw_note bw_xboard_poll
+              bw_xboard_poll_opt bw_xboard_poll_ans bw_user_degree registers)) {
+    my ($n) = $dbh->selectrow_array("SELECT COUNT(*) FROM $t");
+    printf "  %-22s %6d rows\n", $t, $n;
+}
+my ($login_ok) = $dbh->selectrow_array(
+    q{SELECT COUNT(*) FROM bw_xauth_passwd WHERE passwd = ENCRYPT(?, passwd)},
+    undef, $TEST_PASSWORD);
+print "  users whose password verifies as '$TEST_PASSWORD': $login_ok (expect $N_USERS)\n";
+die "FATAL: seeded passwords do not verify\n" unless $login_ok == $N_USERS;
+
+my ($orphan_bodies) = $dbh->selectrow_array(q{
+    SELECT COUNT(*) FROM bw_xboard_header h
+    LEFT JOIN bw_xboard_body b ON b.article_id = h.article_id
+    WHERE b.article_id IS NULL});
+print "  headers without body: $orphan_bodies (expect 0)\n";
+die "FATAL: headers without bodies\n" if $orphan_bodies;
+
+print "\nseed complete. Log in at http://localhost:8080/ as 'root' or 'testuser02' (password: $TEST_PASSWORD)\n";
+$dbh->disconnect;

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -38,8 +38,13 @@
 #     bw_user_gbook, bw_user_support, bw_symp, bw_user_access_history,
 #     bawi_access_stat, bw_note_notify_boxcar, bw_postman_log,
 #     bw_poll* (legacy), bw_xpoll_check, notes (legacy).
-#     User-writable empties are still truncated on reseed (see @owned_tables)
-#     so UI experiments don't survive a "wipe + reseed".
+#     Reseed truncates EVERY base table except schema_migrations (derived
+#     from information_schema, so it can't drift), then reseeds — no UI
+#     experiment survives a "wipe + reseed".
+#     Deterministic caveat: columns with DEFAULT CURRENT_TIMESTAMP that the
+#     seeder leaves unset (bw_xboard_body.modified, bw_user_access
+#     .last_access, organizations.created_date) take the run's wall clock;
+#     every value the seeder writes explicitly is deterministic.
 # =============================================================================
 use strict;
 use warnings;
@@ -78,31 +83,25 @@ die "FATAL: MariaDB ENCRYPT() returned NULL — DES crypt unavailable in the db 
 print "password hash for '$TEST_PASSWORD': $pw_hash\n";
 
 # ------------------------------------------------------------------- wipe
-my @owned_tables = qw(
-    bw_xauth_passwd bw_user_ki bw_user_basic bw_user_sig bw_user_access
-    bw_group bw_group_user
-    bw_xboard_board bw_xboard_header bw_xboard_body bw_xboard_comment
-    bw_xboard_notice bw_xboard_recom bw_xboard_bookmark
-    bw_xboard_scrap bw_xboard_attach bw_xboard_commentref
-    bw_xboard_tag bw_xboard_tagmap bw_xboard_body_html
-    bw_note
-    bw_xboard_poll bw_xboard_poll_opt bw_xboard_poll_ans
-    bw_xpoll bw_xpoll_question bw_xpoll_choice
-    countries schools majors circles registers
-    bw_data_major bw_user_major bw_user_degree bw_user_circle
-    organizations org_alias bw_user_career
-    loads
-    bw_xboard_stat_board bw_xboard_stat_article bw_xboard_stat_user
-    bw_xauth_session
-);
-print "truncating ", scalar(@owned_tables), " tables ...\n";
-$dbh->do("TRUNCATE TABLE $_") for @owned_tables;
+# Truncate every base table except the migration ledger, so "wipe + reseed"
+# is true by construction — a hand-kept list drifts as migrations add tables
+# (and already had: UI-writable tables were missing). No migration seeds
+# reference rows, so truncate-all is safe.
+my $tables = $dbh->selectcol_arrayref(q{
+    SELECT table_name FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'
+      AND table_name <> 'schema_migrations'});
+print "truncating ", scalar(@$tables), " tables ...\n";
+$dbh->do("TRUNCATE TABLE `$_`") for @$tables;
 
 # ------------------------------------------------------------------ users
 # uid 1 = "root": generic admin account name that matches the hardcoded admin
 # list in Bawi::Auth::is_admin, so admin paths are testable. Not a real person.
 my $N_USERS = 50;   # <= 99: 'testuserNN' must fit the app's char(10)/varchar(10) id columns
 die "N_USERS must be <= 99 ('testuser100' would overflow 10-char id columns)\n" if $N_USERS > 99;
+# Floor: registers (uids 46..50), degrees (2..46), careers (2..25) and other
+# blocks hardcode uid ranges; a smaller pool would seed orphan references.
+die "N_USERS must be >= 50 (later blocks hardcode uid ranges up to 50)\n" if $N_USERS < 50;
 print "seeding $N_USERS users (ids: root, testuser02..testuser$N_USERS; password: $TEST_PASSWORD)\n";
 my %uname;   # uid -> display name
 my %uid2id;  # uid -> login id
@@ -456,6 +455,9 @@ print "seeding registration lookups (countries/schools/majors/circles/registers)
 print "seeding degrees / majors / circles per user\n";
 {
     my @types = ('Bachelor','Master','Doctor','Postdoc','Resident','Fellow');
+    # status vocabulary lives in app code, not the schema (varchar):
+    # Bawi::User::get_degree maps exactly these five to display labels.
+    my @statuses = ('graduated','course_completed','admitted','other');
     my $dg = $dbh->prepare(q{
         INSERT INTO bw_user_degree
             (degree_id, uid, type, school_id, department, advisors, content,
@@ -464,7 +466,7 @@ print "seeding degrees / majors / circles per user\n";
     my $did = 0;
     for my $uid (2 .. 46) {
         $did++;
-        my $type    = $types[$uid % 6];             # exercises full career enum
+        my $type    = $types[$uid % 6];   # all 6 bw_user_degree.type values (incl. the 20161225_add_career_enum.sql additions)
         my $start   = BASE_EPOCH - 86400 * 365 * (10 - $uid % 8);
         my $current = $uid % 3 == 0;
         $dg->execute($did, $uid, $type, 1 + ($uid % 6),
@@ -472,7 +474,7 @@ print "seeding degrees / majors / circles per user\n";
                      'synthetic degree record for career-feature testing',
                      d($start),
                      $current ? '1001-01-01' : d($start + 86400 * 365 * 4),
-                     $current ? 'current' : 'completed');
+                     $current ? 'attending' : $statuses[$uid % 4]);
     }
     my $um = $dbh->prepare(q{INSERT INTO bw_user_major (uid, major_id) VALUES (?,?)});
     $um->execute($_, 3 + ($_ % 6)) for 2 .. 41;     # child majors 3..8
@@ -486,8 +488,10 @@ print "seeding career entries (organizations / org_alias / bw_user_career)\n";
     my $org = $dbh->prepare(q{
         INSERT INTO organizations (org_id, name, created_by) VALUES (?,?,1)});
     my $al  = $dbh->prepare(q{INSERT INTO org_alias (alias, org_id) VALUES (?,?)});
+    # App invariant (Bawi::User::add_org): the canonical name is ALWAYS also
+    # an alias — "no alias == invisible org". Keep each name in its list.
     my @ORGS = (        # org_id, canonical name, searchable aliases
-        [1, '가상연구소 (Synthetic Labs)', ['가상연구소', 'Synthetic Labs']],
+        [1, '가상연구소 (Synthetic Labs)', ['가상연구소 (Synthetic Labs)', '가상연구소', 'Synthetic Labs']],
         [2, 'Example Corp',                ['Example Corp', '예제회사']],
         [3, '모의대학병원',                ['모의대학병원']],
         [4, 'Test Foundation',             ['Test Foundation', '테스트재단']],
@@ -511,6 +515,13 @@ print "seeding career entries (organizations / org_alias / bw_user_career)\n";
                      '합성 직위 (synthetic position)',
                      d($start), $ongoing ? undef : d($start + 86400 * 365 * 2));
     }
+    # Edge classes the career UI branches on: unknown start (NULL), a
+    # dangling organization_id ('(삭제된 기관)' path), and second careers
+    # for uids 2 and 3 (exercises the end_date-DESC ordering).
+    $cr->execute(++$cid, 2, 'other', 99, '삭제기관 테스트 (dangling org)',
+                 undef, d(BASE_EPOCH - 86400 * 365 * 8));
+    $cr->execute(++$cid, 3, 'volunteer', 3, '시작일 미상 (unknown start)',
+                 undef, undef);
 }
 
 # ------------------------------------------------------------------- loads
@@ -573,5 +584,5 @@ my ($orphan_bodies) = $dbh->selectrow_array(q{
 print "  headers without body: $orphan_bodies (expect 0)\n";
 die "FATAL: headers without bodies\n" if $orphan_bodies;
 
-print "\nseed complete. Log in at http://localhost:8080/ as 'root' or 'testuser02' (password: $TEST_PASSWORD)\n";
+print "\nseed complete. Log in on this stack's web port (default http://localhost:8080/) as 'root' or 'testuser02' (password: $TEST_PASSWORD)\n";
 $dbh->disconnect;

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -4,7 +4,7 @@
 # =============================================================================
 # Fills the structure-only test schema with clean, obviously-fake data:
 # no real users, no PII, no production content. Every name/id/email/phone is
-# a labeled synthetic value (testuserNN, @example.invalid, 010-0000-xxxx).
+# a labeled synthetic value (testerNN, @example.invalid, 010-0000-xxxx).
 #
 # Deterministic: uses a private LCG (seeded below), so two runs produce
 # byte-identical data on any platform. Re-running truncates and reseeds the
@@ -51,6 +51,8 @@ use warnings;
 use DBI;
 use POSIX qw(strftime);
 
+$| = 1;   # progress lines must not sit in a block buffer under `exec -T` (no TTY)
+
 # ---------------------------------------------------------------- connection
 my $host = $ENV{BAWI_DB_HOST} || 'db';
 my $name = $ENV{BAWI_DB_NAME} || 'bawi';
@@ -94,9 +96,10 @@ print "password hash for '$TEST_PASSWORD': $pw_hash\n";
 # ---------------------------------------------------------------- constants
 # uid 1 = "root": generic admin account name that matches the hardcoded admin
 # list in Bawi::Auth::is_admin, so admin paths are testable. Not a real person.
-my $N_USERS = 50;   # <= 99: 'testuserNN' must fit the app's char(10)/varchar(10) id columns
+my $N_USERS = 50;   # <= 99: 'testerNN' must stay within the app's 3-8 char id
+                    # policy (login form maxlength=8) and its id columns
 # Guards live BEFORE the wipe so a bad edit dies without emptying the DB.
-die "N_USERS must be <= 99 ('testuser100' would overflow 10-char id columns)\n" if $N_USERS > 99;
+die "N_USERS must be <= 99 ('tester100' would break the 8-char id policy)\n" if $N_USERS > 99;
 # Floor: registers (uids 46..50), degrees (2..46), careers (2..25) and other
 # blocks hardcode uid ranges; a smaller pool would seed orphan references.
 die "N_USERS must be >= 50 (later blocks hardcode uid ranges up to 50)\n" if $N_USERS < 50;
@@ -115,7 +118,7 @@ print "truncating ", scalar(@$tables), " tables ...\n";
 $dbh->do("TRUNCATE TABLE `$_`") for @$tables;
 
 # ------------------------------------------------------------------ users
-print "seeding $N_USERS users (ids: root, testuser02..testuser$N_USERS; password: $TEST_PASSWORD)\n";
+print "seeding $N_USERS users (ids: root, tester02..tester$N_USERS; password: $TEST_PASSWORD)\n";
 my %uname;   # uid -> display name
 my %uid2id;  # uid -> login id
 {
@@ -131,7 +134,10 @@ my %uid2id;  # uid -> login id
     for my $uid (1 .. $N_USERS) {
         my ($id, $nm);
         if ($uid == 1) { ($id, $nm) = ('root', '관리자테스트') }
-        else           { $id = sprintf('testuser%02d', $uid); $nm = sprintf('테스트유저%02d', $uid) }
+        # 'tester%02d' = 8 chars: the app's id policy is 3-8 lowercase+digits
+        # and the login form enforces maxlength=8 — a longer synthetic id
+        # could never log in through the real UI.
+        else           { $id = sprintf('tester%02d', $uid); $nm = sprintf('테스트유저%02d', $uid) }
         $uid2id{$uid} = $id;
         $uname{$uid}  = $nm;
         my $modified = dt(BASE_EPOCH + 86400 * (300 + $uid));       # recent-ish
@@ -601,5 +607,5 @@ my ($orphan_bodies) = $dbh->selectrow_array(q{
 print "  headers without body: $orphan_bodies (expect 0)\n";
 die "FATAL: headers without bodies\n" if $orphan_bodies;
 
-print "\nseed complete. Log in on this stack's web port (default http://localhost:8080/) as 'root' or 'testuser02' (password: $TEST_PASSWORD)\n";
+print "\nseed complete. Log in on this stack's web port (default http://localhost:8080/) as 'root' or 'tester02' (password: $TEST_PASSWORD)\n";
 $dbh->disconnect;


### PR DESCRIPTION
## Summary

Publishes the local Docker test environment (developed and validated on the private `test-env` branch) so the repo has a working, documented local dev setup on `main`.

- **docker-compose.yml** — Apache/mod_perl web container + MariaDB 10.6; every published port bound to `127.0.0.1` only (defaults 8080/3307, overridable via `BAWI_HTTP_PORT`/`BAWI_DB_PORT` so multiple worktrees can run stacks side by side); all credentials are throwaway local test values
- **docker/web/** — Ubuntu 22.04 + Apache 2.4 + mod_perl2 + all Perl deps (HTML::ParseBrowser via cpanm — not packaged in 22.04); vhost mirrors `apache2/bawi-spring` and runs the unmodified `apache2/startup.pl` against the repo bind-mounted at the prod path `/home/bawi/bawi-spring`
- **docker/db/init/** — structure-only prod schema (provenance header, DEFINER stripped) + `15-baseline.sql` (pre-records the migrations the dump contains) + a migration runner that executes the rest and warns loudly on non-conforming filenames
- **docker/conf/** — tracked local test configs, bind-mounted read-only onto the gitignored `conf/` (prod keeps its real configs untracked there; nothing is materialized, nothing goes stale)
- **seed/** — deterministic synthetic seeder: 50 fake users, 6 boards, 320 articles (5 markdown/category=1 to exercise `Bawi::Markdown` + the `bw_xboard_body_html` render cache), comments/notes/polls/bookmarks, and career-v3.2 fixtures (4 orgs, 24 careers across the full type enum); no real data, no PII
- **INSTALLATION.md** — run/validate/debug instructions; supersedes the El Capitan-era notes on the `local` branch
- **lib/Bawi/Main/UI.pm** — one line: `use CGI::Cookie;` (it calls `CGI::Cookie->fetch` but relied on `Bawi::Auth` having loaded the module in the same Apache child — a latent load-order 500 on pages that skip Auth). This is the only app-code change; found while building the env, fixed at the root instead of being papered over in the test vhost.

Kept private: `PLAN.md` (internal design/audit notes stay on the local `test-env` branch).

## Review

The branch went through a multi-agent deep review (9 specialized reviewers) plus an independent Codex review; all HIGH/MEDIUM findings were fixed in `26b17e1` (migration-runner redesign to a declarative baseline manifest, read-only conf mount, per-worktree compose isolation, seeder completeness incl. career + markdown fixtures, corrected docs/comments) and re-verified end-to-end on a fresh throwaway stack: migrations baseline/apply correctly, legacy dumps are skipped loudly, seed self-checks pass, a markdown article renders and populates the cache, career/admin pages render, `freq_bookmark` SELECTs, zero web-log errors.

A follow-up mini PR (#22) updates README.md to point here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)