### PR TITLE
perf: memoize successful auth() within the request (halves per-view auth queries)

### DIFF
--- a/lib/Bawi/Auth.pm
+++ b/lib/Bawi/Auth.pm
@@ -149,10 +149,16 @@ sub auth {
 
     # Memoize success: CGIs call auth() 2-4 times per request (guard, then
     # uid/id lookups), and every call costs a session SELECT plus the
-    # update_log UPDATE on bw_xauth_passwd. Only success is cached -- a
-    # failed cookie auth must not short-circuit a later
-    # auth(-session_key=>...) retry (see board/attach.cgi).
-    return 1 if $self->{_authed};
+    # update_log UPDATE on bw_xauth_passwd. Only the argumentless form is
+    # memoized, and only success: a failed cookie auth must not
+    # short-circuit a later auth(-session_key=>...) retry (see
+    # board/attach.cgi), and an explicit -session_key is a different
+    # credential -- it must always be validated, never answered from the
+    # cookie's success. Relies on every CGI constructing its Auth object at
+    # file scope (fresh per ModPerl::Registry run): never call ->auth on an
+    # Auth captured in a named sub's closure, or the memo would replay the
+    # first request's authentication.
+    return 1 if $self->{_authed} && !%arg;
 
     my $session_key;
     if ($arg{-session_key}) {

--- a/lib/Bawi/Auth.pm
+++ b/lib/Bawi/Auth.pm
@@ -178,7 +178,9 @@ sub auth {
         $self->name($session->{name});
         $self->session_key($session_key);
         &update_log($session->{uid});
-        $self->{_authed} = 1;
+        # One-directional with the guard above: only a bare (cookie) success
+        # seeds the memo; a keyed success must not answer a later bare call.
+        $self->{_authed} = 1 unless %arg;
         return 1;
     } else {
         return 0;

--- a/lib/Bawi/Auth.pm
+++ b/lib/Bawi/Auth.pm
@@ -147,6 +147,13 @@ sub session_cookie {
 sub auth {
     my ($self, %arg) = @_;
 
+    # Memoize success: CGIs call auth() 2-4 times per request (guard, then
+    # uid/id lookups), and every call costs a session SELECT plus the
+    # update_log UPDATE on bw_xauth_passwd. Only success is cached -- a
+    # failed cookie auth must not short-circuit a later
+    # auth(-session_key=>...) retry (see board/attach.cgi).
+    return 1 if $self->{_authed};
+
     my $session_key;
     if ($arg{-session_key}) {
         $session_key = $arg{-session_key};
@@ -165,6 +172,7 @@ sub auth {
         $self->name($session->{name});
         $self->session_key($session_key);
         &update_log($session->{uid});
+        $self->{_authed} = 1;
         return 1;
     } else {
         return 0;
@@ -222,6 +230,7 @@ sub logout {
     
     my $session_key = $cookie{ $self->session_cookie->{-name} }->value;
     my $session = &del_session($session_key);
+    delete $self->{_authed};
     $self->uid(undef);
     $self->id(undef);
     $self->name(undef);


### PR DESCRIPTION
## What

`Bawi::Auth::auth()` now memoizes a **successful** authentication for the life of the request object. Repeat calls return immediately instead of re-running the `bw_xauth_session` SELECT and the `update_log` UPDATE (`bw_xauth_passwd SET accessed=NOW(), access=access+1`).

## Why

Every CGI calls `auth()` more than once per request — the access guard, then again for uid/id/name (read.cgi 2-3x, write.cgi 4x, nine CGIs 2+x). Each call is one SELECT **plus one UPDATE to a MyISAM table** (table-level lock), on every page view, sitewide. It also inflates the `access` counter by call count rather than by requests.

## Safety

- Only **success** is cached — a failed cookie auth still allows the explicit `auth(-session_key=>...)` retry that `board/attach.cgi` relies on.
- `logout()` deletes the memo, so post-logout `auth()` in the same request cannot report stale success.
- Under plain CGI (no mod_perl) the object dies with the request; under ModPerl::Registry the object is constructed per request in every entry script, so the memo cannot leak across requests.

## Measured (docker test env, prod-parity `AllowAnonAccess 0`, logged in)

| metric (read.cgi, one view) | before | after |
|---|---|---|
| total queries | 16 | 14 |
| `bw_xauth_session` SELECT | 2 | 1 |
| `bw_xauth_passwd` UPDATE | 2 | 1 |

Smoke tested: fresh login, comment post (row lands), logout → subsequent read.cgi redirects to login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7XWKionHjHMYsWuK6UNqX
