### PR TITLE
feat(board): @mention sends a note; mentions link to note-compose

### DIFF
--- a/board/comment.cgi
+++ b/board/comment.cgi
@@ -79,7 +79,9 @@ if ($xb->board_id && $allow_comment) {
             );
             my $rv = $xb->add_comment(%data);
             $redirect_position = "#c$rv" if $rv;
-            if ($rv && !$xb->is_anonboard) {
+            # $auth->auth: guests set $name from the form -- never let a
+            # request-supplied identity author a note.
+            if ($rv && $auth->auth && !$xb->is_anonboard) {
                 require Bawi::Main::Note;
                 my $proto = $ENV{HTTPS} ? 'https' : 'http';
                 my $dir = $ENV{SCRIPT_NAME} || '';

--- a/board/comment.cgi
+++ b/board/comment.cgi
@@ -79,6 +79,16 @@ if ($xb->board_id && $allow_comment) {
             );
             my $rv = $xb->add_comment(%data);
             $redirect_position = "#c$rv" if $rv;
+            if ($rv && !$xb->is_anonboard) {
+                require Bawi::Main::Note;
+                my $proto = $ENV{HTTPS} ? 'https' : 'http';
+                my $dir = $ENV{SCRIPT_NAME} || '';
+                $dir =~ s#[^/]*$##;
+                my $url = "$proto://$ENV{HTTP_HOST}${dir}read.cgi?bid=$bid;aid=$aid#c$rv";
+                my $note = new Bawi::Main::Note(-dbh=>$ui->dbh);
+                # scan the raw form body: the tweet embed above may add foreign @handles
+                $note->notify_mentions(scalar $q->param('body'), $id, $name, $url);
+            }
         }
     } elsif ($action eq 'delete') {
         if (&check_param($q, qw(bid aid cid)) == 0) {

--- a/board/commentx.cgi
+++ b/board/commentx.cgi
@@ -58,7 +58,9 @@ if ($xb->board_id && $allow_comment) {
                 -name=>$name,
             );
             my $rv = $xb->add_comment(%data);
-            if ($rv && !$xb->is_anonboard) {
+            # $auth->auth: guests set $name from the form -- never let a
+            # request-supplied identity author a note.
+            if ($rv && $auth->auth && !$xb->is_anonboard) {
                 require Bawi::Main::Note;
                 my $proto = $ENV{HTTPS} ? 'https' : 'http';
                 my $dir = $ENV{SCRIPT_NAME} || '';

--- a/board/commentx.cgi
+++ b/board/commentx.cgi
@@ -58,6 +58,15 @@ if ($xb->board_id && $allow_comment) {
                 -name=>$name,
             );
             my $rv = $xb->add_comment(%data);
+            if ($rv && !$xb->is_anonboard) {
+                require Bawi::Main::Note;
+                my $proto = $ENV{HTTPS} ? 'https' : 'http';
+                my $dir = $ENV{SCRIPT_NAME} || '';
+                $dir =~ s#[^/]*$##;
+                my $url = "$proto://$ENV{HTTP_HOST}${dir}read.cgi?bid=$bid;aid=$aid#c$rv";
+                my $note = new Bawi::Main::Note(-dbh=>$ui->dbh);
+                $note->notify_mentions($body, $id, $name, $url);
+            }
         }
     } elsif ($action eq 'delete') {
         if (&check_param($q, qw(bid aid cid p)) == 0) {

--- a/board/write.cgi
+++ b/board/write.cgi
@@ -154,6 +154,15 @@ if ($allow_write && $bid) {
         if ($poll) {
             my $rv = $xb->add_pollset(-query=>$q, -article_id=>$article_id); 
         }
+        unless ($xb->is_anonboard) {
+            require Bawi::Main::Note;
+            my $proto = $ENV{HTTPS} ? 'https' : 'http';
+            my $dir = $ENV{SCRIPT_NAME} || '';
+            $dir =~ s#[^/]*$##;
+            my $url = "$proto://$ENV{HTTP_HOST}${dir}read.cgi?bid=$bid;aid=$article_id";
+            my $note = new Bawi::Main::Note(-dbh=>$ui->dbh);
+            $note->notify_mentions($fbody, $id, $name, $url);
+        }
         print $q->redirect("read.cgi?bid=$bid&aid=$article_id&autosave=1");
         exit (1);
     }

--- a/board/write.cgi
+++ b/board/write.cgi
@@ -154,7 +154,8 @@ if ($allow_write && $bid) {
         if ($poll) {
             my $rv = $xb->add_pollset(-query=>$q, -article_id=>$article_id); 
         }
-        unless ($xb->is_anonboard) {
+        # $auth->auth: only an authenticated member may author a note.
+        if ($auth->auth && !$xb->is_anonboard) {
             require Bawi::Main::Note;
             my $proto = $ENV{HTTPS} ? 'https' : 'http';
             my $dir = $ENV{SCRIPT_NAME} || '';

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -2875,6 +2875,16 @@ sub make_hyperlink {
        (?=\s|[,;\.\)\]]|\D|$)
     } !<a href="#c$3" class="auto comment_no">$2</a>!iogx;
 
+    # @id -> note-compose link, same grammar as _name_id.tmpl (id opens a
+    # note, name opens a profile). Kept last so URLs rewritten above are
+    # not corrupted; skipped on anonymous boards.
+    unless ($self->is_anonboard) {
+      my $note_url = $self->cfg->NoteURL || '../main/note.cgi';
+      s{ ( ^ | [\s\(\[\>] )
+         \@ ([A-Za-z0-9_]{2,10}) \b
+      } !$1<a class="user-message" target="bw_message" href="$note_url?to_default=$2">\@$2</a>!ogx;
+    }
+
   }
   return $_;
 }

--- a/lib/Bawi/Main/Note.pm
+++ b/lib/Bawi/Main/Note.pm
@@ -91,6 +91,33 @@ sub send_msg {
     return $rv;
 }
 
+sub notify_mentions {
+    my $self = shift;
+    my $body = shift || "";
+    my $from_id = shift || "";
+    my $from_name = shift || "";
+    my $url = shift || "";
+
+    return 0 if ($body eq "" || $from_id eq "" || $from_name eq "" || $url eq "");
+
+    my (@ids, %seen);
+    while ($body =~ /(?:^|[\s\(\[\>])\@([A-Za-z0-9_]{2,10})\b/g) {
+        next if ($1 eq $from_id || $seen{$1});
+        $seen{$1} = 1;
+        push @ids, $1;
+        last if (@ids >= 5); # cap: notify at most 5 mentioned users per post
+    }
+
+    my $sent = 0;
+    foreach my $id (@ids) {
+        my $user = $self->get_user_info_by_id($id);
+        next unless ($user && $user->{name});
+        my $msg = "[언급] ${from_name}(${from_id})님이 회원님을 언급했습니다: $url";
+        ++$sent if $self->send_msg($id, $user->{name}, $from_id, $from_name, $msg);
+    }
+    return $sent;
+}
+
 sub delete_msg {
     my $self = shift;
     my $msg_id = shift;

--- a/lib/Bawi/Main/Note.pm
+++ b/lib/Bawi/Main/Note.pm
@@ -108,11 +108,18 @@ sub notify_mentions {
         last if (@ids >= 5); # cap: notify at most 5 mentioned users per post
     }
 
+    # msg is rendered as HTML by the note pages: keep the interpolated
+    # sender fields inert even if a caller passes request-derived values.
+    my ($e_name, $e_id) = ($from_name, $from_id);
+    for ($e_name, $e_id) {
+        s/&/&amp;/g; s/</&lt;/g; s/>/&gt;/g; s/"/&quot;/g;
+    }
+
     my $sent = 0;
     foreach my $id (@ids) {
         my $user = $self->get_user_info_by_id($id);
         next unless ($user && $user->{name});
-        my $msg = "[언급] ${from_name}(${from_id})님이 회원님을 언급했습니다: $url";
+        my $msg = "[언급] ${e_name}(${e_id})님이 회원님을 언급했습니다: $url";
         ++$sent if $self->send_msg($id, $user->{name}, $from_id, $from_name, $msg);
     }
     return $sent;

--- a/lib/Bawi/Main/Note.pm
+++ b/lib/Bawi/Main/Note.pm
@@ -100,6 +100,11 @@ sub notify_mentions {
 
     return 0 if ($body eq "" || $from_id eq "" || $from_name eq "" || $url eq "");
 
+    # callers build $url from the request (Host header): accept only a
+    # plain http(s)://host[:port]/path shape -- a forged Host must not
+    # smuggle markup or control chars into the stored note.
+    return 0 unless ($url =~ m{^https?://[A-Za-z0-9.\-]+(?::\d+)?/[\w\-./?;=&#%]*$});
+
     my (@ids, %seen);
     while ($body =~ /(?:^|[\s\(\[\>])\@([A-Za-z0-9_]{2,10})\b/g) {
         next if ($1 eq $from_id || $seen{$1});
@@ -109,9 +114,9 @@ sub notify_mentions {
     }
 
     # msg is rendered as HTML by the note pages: keep the interpolated
-    # sender fields inert even if a caller passes request-derived values.
-    my ($e_name, $e_id) = ($from_name, $from_id);
-    for ($e_name, $e_id) {
+    # request-derived fields inert.
+    my ($e_name, $e_id, $e_url) = ($from_name, $from_id, $url);
+    for ($e_name, $e_id, $e_url) {
         s/&/&amp;/g; s/</&lt;/g; s/>/&gt;/g; s/"/&quot;/g;
     }
 
@@ -119,7 +124,7 @@ sub notify_mentions {
     foreach my $id (@ids) {
         my $user = $self->get_user_info_by_id($id);
         next unless ($user && $user->{name});
-        my $msg = "[언급] ${e_name}(${e_id})님이 회원님을 언급했습니다: $url";
+        my $msg = "[언급] ${e_name}(${e_id})님이 회원님을 언급했습니다: $e_url";
         ++$sent if $self->send_msg($id, $user->{name}, $from_id, $from_name, $msg);
     }
     return $sent;


### PR DESCRIPTION
> **For review only — please do not merge yet.**

## Behavior

**Commit 1 — mention notes.** When an article (`board/write.cgi`) or comment (`board/comment.cgi`, `board/commentx.cgi`) is posted containing `@<userid>` tokens, each mentioned user receives a note (쪽지) through the existing `Bawi::Main::Note::send_msg` path:

```
[언급] <from_name>(<from_id>)님이 회원님을 언급했습니다: <article URL>
```

The header already polls `main/note_check.cgi` every 60s (`main/skin/default/script.js`), so delivery UI comes for free.

**Commit 2 — linkified mentions.** In rendered legacy bodies and comments, `@id` tokens become the site's standard id link:

```html
<a class="user-message" target="bw_message" href="../main/note.cgi?to_default=id">@id</a>
```

## Token rules (shared by both commits)

- `@` must be preceded by start-of-string or one of whitespace / `(` / `[` / `>`; the id is `[A-Za-z0-9_]{2,10}` with a trailing `\b` (`bw_xauth_passwd.id` caps at 10 chars in practice; an 11+-char run simply doesn't match).
- Emails (`foo@bar.com`) and mid-word `@` never match; `@id님` (Korean immediately after) does.
- Notify path only: ids are uniqued preserving order, the author (`from_id`) is dropped, capped at **5 notes per post**, and ids with no `bw_xauth_passwd` row are silently skipped (one `SELECT` per candidate id, write-time only).
- `comment.cgi` scans the **raw form body**, not the tweet-embed-expanded one, so a fetched Twitter blockquote (which always contains `(@handle)`) can't fire phantom notes at Bawi users whose id collides with a Twitter handle.

## Anonymous boards

Both sides are inert on anonymous boards: the hooks skip `notify_mentions` entirely when `$xb->is_anonboard` (a note would leak who wrote the post), and `make_hyperlink` skips the linkify rule when `$self->is_anonboard` (no id-shaped links on boards that scrub identity).

## Why absolute URLs in the notes

Notes are read from `main/note.cgi`, where a relative `read.cgi?...` link would resolve against `main/`, not `board/`. Also `Note.pm`'s own `make_hyperlink` only auto-links `http(s)://` URLs, so a relative path wouldn't even become clickable. The hook builds `http(s)://$ENV{HTTP_HOST}<dir of SCRIPT_NAME>read.cgi?bid=..;aid=..` from the request env; comment hooks append the `#c<comment_no>` anchor already in scope (`add_comment` returns the comment_no).

## Why linkify targets note-compose

Site grammar from `board/skin/default/_name_id.tmpl`: a user's **name** links to profile (`user-profile`/`bw_profile`), a user's **id** links to note-compose (`user-message`/`bw_message`, `note.cgi?to_default=<id>`). An `@mention` token is an id, so it gets the id treatment, same class/target/href shape. `NoteURL` is taken from the board cfg (`$self->cfg->NoteURL`, the accessor Board.pm already uses for other keys) with a hardcoded `../main/note.cgi` fallback — correct relative to all `board/` pages.

## Why markdown bodies don't linkify

`category==1` (markdown) bodies never pass through `Board.pm::make_hyperlink`, consistent with them not getting URL auto-linking today either; the markdown pipeline is untouched. Comments — the main mention surface — always use the legacy formatter, so they always linkify. The new rule runs **last**, after the URL/`#comment` rules, so URLs containing `@` are already inside `<a>` tags and can't be corrupted (covered in the smoke tests below).

## Cost

Write-time only: up to 6 extra queries per mention-bearing post (≤5 candidate id lookups + ≤5 `INSERT`s into `bw_note`). **Zero read-path queries** — rendering does no DB validation; a typo'd `@id` just links to a compose page.

## Non-goals (deliberate)

- `update.cgi` (edits) does not re-notify.
- Quoting a comment containing `@id` DOES re-notify (accepted).
- Mentions are inert on anonymous boards.

## Verification

- `perl -Ilib -c` passes for all five touched/affected files (`lib/Bawi/Main/Note.pm`, `lib/Bawi/Board.pm`, `board/write.cgi`, `board/comment.cgi`, `board/commentx.cgi`); the CGIs need local stubs for CPAN modules absent on the dev Mac (HTML::Template, HTML::ParseBrowser, Image::Magick, Text::Iconv) — a pre-existing environment gap, identical on `origin/main`.
- Mocked-dbh smoke tests: 13/13 assertions on `notify_mentions` (prefix forms, email/short/long negatives, dedup, self-drop, cap, unknown-id skip, Korean adjacency, empty-arg guards) and 14/14 on the linkify rule (all prefix forms, email/URL non-corruption, `#no` coexistence, anonboard skip, NoteURL fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kmmi9DTd7o7wV8ScorYFSC
