### PR TITLE
note: conversation search lands on a stale page number

### DIFF
--- a/main/skin/default/note.tmpl
+++ b/main/skin/default/note.tmpl
@@ -10,8 +10,6 @@
 <label>대화상대(아이디)</label>
 <input type="text" name="correspondent" value="<tmpl_var correspondent>"/>
 <input type="hidden" name="mbox" value="<tmpl_var mbox>"/>
-<tmpl_else>
-<input type="hidden" name="correspondent" value="<tmpl_var correspondent>"/>
 </form>
 </tmpl_if>
 


### PR DESCRIPTION
## Problem
Finding a conversation in the note service (대화상대 search box) lands on an outdated page instead of the latest one.

## Root cause
In `note.tmpl` the conversation search form's `</form>` only rendered in the *non*-conversation branch, so in conversation view the GET form stayed open. Per HTML5 form-pointer parsing, the first message's nested `<form method="post">` start tag is ignored and its hidden inputs — `mbox`, `wait`, and `page` (the currently viewed page, via `global_vars`) — are absorbed into the search form. Submitting a search therefore carried the previous view's page number, and `get_messages` honors an explicit `page` instead of defaulting to `tot_page` (the newest page — pagination here anchors newest = highest).

## Fix
Close the form inside the conversation branch; drop the else-branch orphan (hidden input + stray `</form>` outside any form — dead markup in non-conversation views). Template-only, 2 deletions; no Perl change. The server can't distinguish a stale page from a deliberate old-page click, so the template is the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)