### PR TITLE
style: align Fable-era merged code with pre-existing house conventions

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -79,7 +79,7 @@ docker compose restart web            # REQUIRED after editing lib/Bawi/*.pm
                                       #  picked up on the next request)
 ./seed/reseed.sh                      # wipe + reseed synthetic data
 docker compose exec web bash          # shell in the web container
-mysql -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi   # DB from host (your BAWI_DB_PORT if overridden)
+mariadb -h 127.0.0.1 -P 3307 -u bawi_test -pbawi-local-test-pw bawi   # DB from host (your BAWI_DB_PORT if overridden)
 docker compose down                   # stop (data volumes kept)
 docker compose down -v                # stop and DESTROY db + attachment + photo volumes
 ```
@@ -152,7 +152,7 @@ retrying — a half-initialized data dir skips init on the next start.
 ## Validation checklist (what "working" looks like)
 
 1. `docker compose ps` — the db and web containers both `Up`.
-2. `docker compose exec -T db mysql -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 lines: 1 column-header line + 61 tables (incl. `schema_migrations`) + the `freq_bookmark` view. (Grows by one per table a migration adds — cross-check against the runner's state listing in `docker compose logs db`.)
+2. `docker compose exec -T db mariadb -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 63 lines: 1 column-header line + 61 tables (incl. `schema_migrations`) + the `freq_bookmark` view. (Grows by one per table a migration adds — cross-check against the runner's state listing in `docker compose logs db`.)
 3. `curl -s http://localhost:8080/main/db-test.cgi` → three `before query:/after query:/dbh->errstr:` lines then the six seeded board titles (no 500).
 4. `curl -s http://localhost:8080/` → login page HTML (200).
 5. Login POST (see above) → `302` with `Set-Cookie: bawi_session=…`.

--- a/admin/organizations.cgi
+++ b/admin/organizations.cgi
@@ -9,14 +9,9 @@ use Bawi::User;
 my $ui = new Bawi::Main::UI(-main_dir=>'admin', -template=>'organizations.tmpl');
 my $auth = new Bawi::Auth(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
 
-unless ($auth->auth) {
-    print $auth->login_page($ui->cgiurl);
-    exit(1);
-}
-
-unless ($auth->is_admin) {
+unless ($auth->auth_admin) {
     print $auth->access_denied($ui->cgiurl);
-    exit(1);
+    exit (1);
 }
 
 $ui->tparam(HTMLTitle => "경력기관 관리");

--- a/board/myarticle.cgi
+++ b/board/myarticle.cgi
@@ -27,7 +27,7 @@ if ($auth->auth) {
 }
 
 my $board_id = $q->param('bid') || 0;
-$board_id = 0 unless $board_id =~ /^\d+$/;   # reflected into the url tparam (page-nav hrefs)
+$board_id = 0 unless ($board_id =~ /^\d+$/);   # reflected into the url tparam (page-nav hrefs)
 my $sql;
 my $rv;
 
@@ -46,7 +46,7 @@ my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
 my $p = $q->param('p') || '';
-$p = '' unless $p =~ /^\d+$/;   # no p sink in this page's templates; kept numeric so the $page arithmetic below stays sane
+$p = '' unless ($p =~ /^\d+$/);   # no p sink in this page's templates; kept numeric so the $page arithmetic below stays sane
 my $page = $p;
 $page = $tot_page unless ($page && $page <= $tot_page);
 
@@ -83,13 +83,13 @@ $t->param(pages=>\@pages);
 $t->param(p=>$p);
 $t->param(total=>$articles);
 
-# The board list page (read.cgi's p=) this article appears on — pages are
+# The board list page (read.cgi's p=) this article appears on -- pages are
 # reverse-numbered (tot_page = newest), matching get_tot_page/get_start in
 # Bawi::Board; read.cgi clamps if the denormalized c.articles has drifted.
 # CAST ... AS SIGNED: c.articles/c.article_per_page are UNSIGNED, so if the
 # counter has drifted low the CEIL-FLOOR difference goes negative and an
 # unsigned subtraction raises ER_DATA_OUT_OF_RANGE (1690) instead of letting
-# GREATEST clamp it — the SIGNED cast keeps the drift case a clamp, not a 500.
+# GREATEST clamp it -- the SIGNED cast keeps the drift case a clamp, not a 500.
 my $board_page = qq(IF(c.article_per_page > 0,
                        GREATEST(1, CAST(CEIL(c.articles / c.article_per_page) AS SIGNED) -
                                    CAST(FLOOR((SELECT count(*) FROM bw_xboard_header as h

--- a/board/mycomment.cgi
+++ b/board/mycomment.cgi
@@ -27,7 +27,7 @@ if ($auth->auth) {
 }
 
 my $board_id = $q->param('bid') || 0;
-$board_id = 0 unless $board_id =~ /^\d+$/;   # reflected into the url tparam (page-nav hrefs)
+$board_id = 0 unless ($board_id =~ /^\d+$/);   # reflected into the url tparam (page-nav hrefs)
 my $sql;
 my $rv;
 
@@ -46,7 +46,7 @@ my $tot_page = int ($articles / $article_per_page);
 ++$tot_page if ($articles % $article_per_page);
 $tot_page = 1 if ($tot_page < 1);
 my $p = $q->param('p') || '';
-$p = '' unless $p =~ /^\d+$/;   # no p sink in this page's templates; kept numeric so the $page arithmetic below stays sane
+$p = '' unless ($p =~ /^\d+$/);   # no p sink in this page's templates; kept numeric so the $page arithmetic below stays sane
 my $page = $p;
 $page = $tot_page unless ($page && $page <= $tot_page);
 
@@ -90,17 +90,17 @@ $t->param(total=>$articles);
 # bid-filtered the filtered page number would be applied to the UNFILTERED
 # listing (a different, usually larger, page space) and land on the wrong
 # page. In the filtered case emit an empty p instead, which mycomment.cgi
-# then clamps to the newest page — the pre-existing behaviour for that flow.
+# then clamps to the newest page -- the pre-existing behaviour for that flow.
 $t->param(cur_page=>$board_id ? '' : $page);
 
-# The board list page (read.cgi's p=) the comment's article appears on —
+# The board list page (read.cgi's p=) the comment's article appears on --
 # pages are reverse-numbered (tot_page = newest), matching get_tot_page/
 # get_start in Bawi::Board. The templates always forwarded p=<tmpl_var page>,
 # but no page column was ever selected, so the link carried an empty p.
 # CAST ... AS SIGNED: c.articles/c.article_per_page are UNSIGNED, so if the
 # counter has drifted low the CEIL-FLOOR difference goes negative and an
 # unsigned subtraction raises ER_DATA_OUT_OF_RANGE (1690) instead of letting
-# GREATEST clamp it — the SIGNED cast keeps the drift case a clamp, not a 500.
+# GREATEST clamp it -- the SIGNED cast keeps the drift case a clamp, not a 500.
 my $board_page = qq(IF(c.article_per_page > 0,
                        GREATEST(1, CAST(CEIL(c.articles / c.article_per_page) AS SIGNED) -
                                    CAST(FLOOR((SELECT count(*) FROM bw_xboard_header as h

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # =============================================================================
 # SECURITY / LOCAL-ONLY NETWORKING:
 #   Every published port below is explicitly bound to 127.0.0.1. This stack
-#   must only ever be reachable from this machine's localhost — never the LAN
+#   must only ever be reachable from this machine's localhost -- never the LAN
 #   or the internet. Do NOT change "127.0.0.1:${BAWI_HTTP_PORT:-8080}:80" to a
 #   bare "8080:80" (a bare host port makes Docker publish on 0.0.0.0, i.e.
 #   all interfaces).
@@ -12,12 +12,12 @@
 # secrets anywhere). The DB coordinate tuple (bawi / bawi_test /
 # bawi-local-test-pw / host "db") is repeated, deliberately un-templated, in:
 # both service env blocks below, docker/conf/*.conf (the app reads those),
-# docker/web/entrypoint.sh defaults, and seed/seed.pl defaults — change one,
+# docker/web/entrypoint.sh defaults, and seed/seed.pl defaults -- change one,
 # change all.
 #
 # Compose project name comes from the checkout directory BASENAME, so each
 # uniquely-named worktree gets its own isolated stack (two checkouts with the
-# same basename would share one — disambiguate with `docker compose -p`).
+# same basename would share one -- disambiguate with `docker compose -p`).
 # Override the two host ports to run several stacks at once, persistently via
 # a gitignored .env file: printf 'BAWI_HTTP_PORT=8081\nBAWI_DB_PORT=3308\n' > .env
 # (a one-off env prefix works too, but is forgotten by the next bare
@@ -46,8 +46,8 @@ services:
       # read-only, for the migration runner.
       - ./db:/bawi-migrations:ro
     ports:
-      # localhost-only, for host-side inspection (mysql client / GUI):
-      #   mysql -h 127.0.0.1 -P ${BAWI_DB_PORT:-3307} -u bawi_test -pbawi-local-test-pw bawi
+      # localhost-only, for host-side inspection (mariadb client / GUI):
+      #   mariadb -h 127.0.0.1 -P ${BAWI_DB_PORT:-3307} -u bawi_test -pbawi-local-test-pw bawi
       - "127.0.0.1:${BAWI_DB_PORT:-3307}:3306"
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
@@ -62,7 +62,7 @@ services:
       - db
     environment:
       # Used by the entrypoint wait-loop and seed/seed.pl (the app itself
-      # reads conf/*.conf — mounted below — which point at the same DB).
+      # reads conf/*.conf -- mounted below -- which point at the same DB).
       BAWI_DB_HOST: db
       BAWI_DB_NAME: bawi
       BAWI_DB_USER: bawi_test
@@ -74,11 +74,11 @@ services:
       # in-process caches when editing lib/*.pm).
       - .:/home/bawi/bawi-spring
       # Tracked local test configs, shadowing the host's conf/ inside the
-      # container (conf/*.conf is gitignored — prod keeps real configs
+      # container (conf/*.conf is gitignored -- prod keeps real configs
       # untracked there). Nested read-only bind: always exactly the tracked
       # files, nothing materialized, nothing to go stale.
       - ./docker/conf:/home/bawi/bawi-spring/conf:ro
-      # BAWI_DATA_HOME (attachment uploads) and the photo dir — kept out of
+      # BAWI_DATA_HOME (attachment uploads) and the photo dir -- kept out of
       # the repo; paths are hardcoded in startup.pl / the photo CGIs.
       - bawi-data:/home/bawi/bawi-data
       - bawi-photos:/home/bawi/photo_attach

--- a/docker/conf/board.conf
+++ b/docker/conf/board.conf
@@ -1,5 +1,5 @@
 # ##############################################################################
-# BawiX Configuration — LOCAL DOCKER TEST ENVIRONMENT (generated from
+# BawiX Configuration -- LOCAL DOCKER TEST ENVIRONMENT (generated from
 # board.conf.sample). Credentials below are throwaway local test
 # values that only exist inside the docker-compose network. NOT for prod.
 #

--- a/docker/conf/main.conf
+++ b/docker/conf/main.conf
@@ -1,5 +1,5 @@
 # ##############################################################################
-# BawiX Configuration — LOCAL DOCKER TEST ENVIRONMENT (generated from
+# BawiX Configuration -- LOCAL DOCKER TEST ENVIRONMENT (generated from
 # main.conf.sample). Credentials below are throwaway local test
 # values that only exist inside the docker-compose network. NOT for prod.
 #

--- a/docker/conf/user.conf
+++ b/docker/conf/user.conf
@@ -1,5 +1,5 @@
 # ##############################################################################
-# BawiX Configuration — LOCAL DOCKER TEST ENVIRONMENT (generated from
+# BawiX Configuration -- LOCAL DOCKER TEST ENVIRONMENT (generated from
 # user.conf.sample). Credentials below are throwaway local test
 # values that only exist inside the docker-compose network. NOT for prod.
 #

--- a/docker/db/init/10-schema.sql
+++ b/docker/db/init/10-schema.sql
@@ -5,12 +5,12 @@
 --              lines stripped; the freq_bookmark view's prod DEFINER clause
 --              removed so the view is SELECTable in the test DB, which has
 --              no `bawi`@`localhost` user)
---   contains:  all migrations up to and including 20221221 — see
+--   contains:  all migrations up to and including 20221221 -- see
 --              15-baseline.sql, which records exactly that set.
 -- WHEN REFRESHING THIS FILE from prod: strip the DEFINER clause again and
 -- update 15-baseline.sql to list every dated migration the new dump
--- reflects — a missed entry is re-executed (non-idempotent DDL aborts
--- first boot; idempotent migrations re-run silently — verify by hand).
+-- reflects -- a missed entry is re-executed (non-idempotent DDL aborts
+-- first boot; idempotent migrations re-run silently -- verify by hand).
 -- ===========================================================================
 /*M!999999\- enable the sandbox mode */
 

--- a/docker/db/init/15-baseline.sql
+++ b/docker/db/init/15-baseline.sql
@@ -8,7 +8,7 @@
 --
 -- REGENERATE THIS LIST WHENEVER 10-schema.sql IS REFRESHED: add a baseline
 -- row for every dated migration the new dump reflects. A missed entry gets
--- re-executed on first boot — non-idempotent DDL aborts loudly (duplicate
+-- re-executed on first boot -- non-idempotent DDL aborts loudly (duplicate
 -- CREATE TABLE), but idempotent migrations (ALTER MODIFY, data UPDATEs,
 -- DROP IF EXISTS+CREATE) re-run SILENTLY, so verify those by hand.
 --

--- a/docker/db/init/20-apply-migrations.sh
+++ b/docker/db/init/20-apply-migrations.sh
@@ -6,27 +6,27 @@
 # in db/ are legacy FULL DUMPS and are never executed; any other *.sql name
 # is skipped with a loud warning (rename it to the dated pattern to run it).
 # Data in migrations: transforms of existing rows are fine (reseed
-# regenerates data — keep seed.pl emitting the post-migration shape).
+# regenerates data -- keep seed.pl emitting the post-migration shape).
 # Reference rows prod needs MAY ride in
-# the migration (idempotently) for prod's sake — db/ is also the prod
-# migration channel — but MUST then be mirrored in seed/seed.pl, because
+# the migration (idempotently) for prod's sake -- db/ is also the prod
+# migration channel -- but MUST then be mirrored in seed/seed.pl, because
 # reseed truncates every base table except schema_migrations.
 #
 # Double-apply protection is the schema_migrations tracking table alone:
 # migrations already contained in 10-schema.sql are pre-recorded as
 # status='baseline' by 15-baseline.sql (which runs first and also creates the
 # table); everything not recorded is executed and recorded as 'applied'.
-# REFRESHING THE DUMP: update 15-baseline.sql in the same commit — a missed
+# REFRESHING THE DUMP: update 15-baseline.sql in the same commit -- a missed
 # baseline entry gets re-executed: non-idempotent DDL aborts first boot
 # loudly, but idempotent migrations (ALTER MODIFY, data UPDATEs, DROP IF
-# EXISTS+CREATE) re-run SILENTLY — verify those rows by hand.
+# EXISTS+CREATE) re-run SILENTLY -- verify those rows by hand.
 #
 # This file is executable ON PURPOSE: the official mariadb entrypoint runs
 # executable init hooks as a child process (it would source a non-executable
 # one into its own shell, leaking our set -e/shopt). The child doesn't
 # inherit the entrypoint's internal SQL helper functions, so both contexts
 # call the plain mariadb client below:
-#   a) first-boot init hook — the entrypoint's temp server listens on the
+#   a) first-boot init hook -- the entrypoint's temp server listens on the
 #      default socket and the root password is already set. Requires the
 #      plain MARIADB_ROOT_PASSWORD env form (a _FILE/RANDOM variant would
 #      break the client call below).
@@ -57,10 +57,10 @@ sql_query "SELECT 1" >/dev/null
 # init runs it before this script). With the DB reachable, a missing/empty
 # table means the DB was never legitimately initialized (e.g. a first boot
 # that died mid-schema, then restarted with a non-empty datadir, which skips
-# init) — re-executing migrations against unknown state is wrong, fail closed.
+# init) -- re-executing migrations against unknown state is wrong, fail closed.
 recorded=$(sql_query "SELECT COUNT(*) FROM schema_migrations" 2>/dev/null) || recorded=""
 if [ -z "$recorded" ] || [ "$recorded" = "0" ]; then
-    echo "[migrations] FATAL: schema_migrations is missing or empty — this DB was not initialized by 15-baseline.sql (a failed first boot?). Rebuild with: docker compose down -v && docker compose up -d" >&2
+    echo "[migrations] FATAL: schema_migrations is missing or empty -- this DB was not initialized by 15-baseline.sql (a failed first boot?). Rebuild with: docker compose down -v && docker compose up -d" >&2
     exit 1
 fi
 
@@ -86,15 +86,15 @@ for f in "$MIGRATIONS_DIR"/*.sql; do
     case "$base" in
         [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_*.sql) ;;
         bawi_*.sql)
-            echo "[migrations] $base: legacy full dump — never executed"
+            echo "[migrations] $base: legacy full dump -- never executed"
             continue ;;
         *)
-            echo "[migrations] WARNING: $base does not match YYYYMMDD_*.sql — NOT applied (rename it to run)" >&2
+            echo "[migrations] WARNING: $base does not match YYYYMMDD_*.sql -- NOT applied (rename it to run)" >&2
             continue ;;
     esac
     found=1
     if is_recorded "$base"; then
-        echo "[migrations] $base: already recorded — skip"
+        echo "[migrations] $base: already recorded -- skip"
         continue
     fi
     echo "[migrations] $base: applying"
@@ -103,7 +103,7 @@ for f in "$MIGRATIONS_DIR"/*.sql; do
 done
 if [ "$found" != "1" ]; then
     # The repo always ships dated migrations; an empty dir means a broken
-    # mount or MIGRATIONS_DIR override — never a state to bless silently.
+    # mount or MIGRATIONS_DIR override -- never a state to bless silently.
     echo "[migrations] FATAL: no dated migration files found in $MIGRATIONS_DIR" >&2
     exit 1
 fi

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,7 +1,7 @@
 # Web container for the bawi-on-perl LOCAL test environment.
 # Mirrors production: Ubuntu 22.04, Apache 2.4 + mod_perl2 (ModPerl::Registry),
 # Perl 5.34, MariaDB client libs. The application code is NOT baked into the
-# image — the repo working tree is bind-mounted at /home/bawi/bawi-spring.
+# image -- the repo working tree is bind-mounted at /home/bawi/bawi-spring.
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # HTML::ParseBrowser is a HARD dependency of Bawi::Auth (use'd at
 # lib/Bawi/Auth.pm:10, hit on every login) but is NOT packaged in Ubuntu
-# 22.04 ("Unable to locate package libhtml-parsebrowser-perl") — install it
+# 22.04 ("Unable to locate package libhtml-parsebrowser-perl") -- install it
 # from CPAN. The perl -M gate below fails the build if this ever breaks.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends cpanminus make \

--- a/docker/web/bawi-test.conf
+++ b/docker/web/bawi-test.conf
@@ -1,7 +1,7 @@
 # Test-environment vhost for bawi-on-perl.
 # Mirrors the production vhost (apache2/bawi-spring, the *:443 block) with the
 # minimum test-env deltas:
-#   - plain HTTP on :80 (no TLS, no www.bawi.org rewrite) — the container port
+#   - plain HTTP on :80 (no TLS, no www.bawi.org rewrite) -- the container port
 #     is published on 127.0.0.1 only (see docker-compose.yml)
 #   - Apache 2.2 "Order/Allow" lines replaced by their 2.4 equivalent
 #     "Require all granted" (prod relies on mod_access_compat for those)

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -3,7 +3,7 @@
 # 1. Prepare BAWI_DATA_HOME (attachments) and the photo dir with www-data
 #    ownership. App config needs no step here: docker-compose.yml bind-mounts
 #    docker/conf/ read-only onto conf/, so the tracked test configs are always
-#    the live ones (edit docker/conf/*.conf on the host — the app re-reads
+#    the live ones (edit docker/conf/*.conf on the host -- the app re-reads
 #    configs on every request, no restart needed).
 # 2. Wait (bounded) for MariaDB so first-request behavior is deterministic.
 # 3. Run Apache in the foreground.

--- a/lib/Bawi/ImageSig.pm
+++ b/lib/Bawi/ImageSig.pm
@@ -11,6 +11,7 @@ package Bawi::ImageSig;
 # which previously each carried their own copy of the same magic-byte check.
 ################################################################################
 use strict;
+use warnings;
 
 # leading magic-byte signature -> canonical format name
 my @SIGNATURE = (
@@ -22,9 +23,9 @@ my @SIGNATURE = (
 # Return the canonical format name of $bytes' leading signature, or undef.
 sub sniff {
     my $bytes = shift;
-    return undef unless defined $bytes;
-    for my $s (@SIGNATURE) {
-        return $s->[0] if $bytes =~ $s->[1];
+    return undef unless (defined $bytes);
+    foreach my $s (@SIGNATURE) {
+        return $s->[0] if ($bytes =~ $s->[1]);
     }
     return undef;
 }

--- a/lib/Bawi/Markdown.pm
+++ b/lib/Bawi/Markdown.pm
@@ -149,7 +149,7 @@ sub render {
         $code =~ s/'/&#39;/g;
         $pfx . "\n" . $pfx
             . $shield->('<pre><code'
-                        . ($lang ? qq{ class="language-$lang"} : '')
+                        . ($lang ? qq( class="language-$lang") : '')
                         . '>' . $code . '</code></pre>')
             . "\n" . $pfx;
     }egms;
@@ -223,7 +223,7 @@ sub render {
                 # The definition's backlink points at the first cite.
                 my $k = ++$fnseen{$1};
                 my $refid = $k == 1 ? "fnref-$uniq$n" : "fnref-$uniq$n-$k";
-                qq{<sup id="$refid"><a href="#fn-$uniq$n">$n</a></sup>};
+                qq(<sup id="$refid"><a href="#fn-$uniq$n">$n</a></sup>);
             } else {
                 "[^$1]";   # no such definition: leave it literal
             }
@@ -257,10 +257,10 @@ sub render {
     # 3b. the footnote list itself, appended last so its content may
     #     hold shielded math (restored by stage 9 below)
     if (@fnorder) {
-        my $fn = qq{<div class="footnotes"><hr /><ol>};
-        for my $i (1 .. @fnorder) {
-            $fn .= qq{<li id="fn-$uniq$i">} . _span_md($fndef{$fnorder[$i-1]})
-                 . qq{ <a href="#fnref-$uniq$i">&#8617;</a></li>};
+        my $fn = qq(<div class="footnotes"><hr /><ol>);
+        foreach my $i (1 .. @fnorder) {
+            $fn .= qq(<li id="fn-$uniq$i">) . _span_md($fndef{$fnorder[$i-1]})
+                 . qq( <a href="#fnref-$uniq$i">&#8617;</a></li>);
         }
         $body .= $fn . '</ol></div>';
     }
@@ -396,7 +396,7 @@ sub _pipe_tables {
                 my @align = map {
                     /^:-*:$/ ? 'center' : /-:$/ ? 'right' : /^:/ ? 'left' : ''
                 } @sep;
-                my $attr = sub { $align[$_[0]] ? qq{ align="$align[$_[0]]"} : '' };
+                my $attr = sub { $align[$_[0]] ? qq( align="$align[$_[0]]") : '' };
                 my $html = '<table><thead><tr>';
                 $html .= '<th' . $attr->($_) . '>' . _span_md($hdr[$_]) . '</th>'
                     for 0 .. $#hdr;

--- a/lib/Bawi/User.pm
+++ b/lib/Bawi/User.pm
@@ -355,7 +355,8 @@ sub has_career {
     my ($self, $uid) = @_;
     my $ki = $self->ki($uid);
     my $max_ki = $self->max_ki;
-    my $rv = $DBH->selectrow_array(qq(select count(*) from bw_user_career where uid=?), undef, $uid);
+    my $sql = qq(select count(*) from bw_user_career where uid=?);
+    my $rv = $DBH->selectrow_array($sql, undef, $uid);
     return $rv || $max_ki - $ki < 5 ? 1 : 0;
 }
 
@@ -474,15 +475,22 @@ sub del_degree {
     return $rv;
 }
 
-our %CAREER_TYPE = (employment=>'재직', internship=>'인턴', volunteer=>'봉사', research=>'연구', military=>'군복무', other=>'기타');   # SINGLE SOURCE for the Perl side. Keep in
-# sync with the DB enum (db/20260708_create_career.sql) and the <option> list in
-# user/skin/default/career.tmpl — those two are parallel copies the template/SQL can't
-# read from here.
+# SINGLE SOURCE for the Perl side. Keep in sync with the DB enum
+# (db/20260708_create_career.sql) and the <option> list in
+# user/skin/default/career.tmpl -- those two are parallel copies the
+# template/SQL can't read from here.
+our %CAREER_TYPE = (employment=>'재직', internship=>'인턴', volunteer=>'봉사', research=>'연구', military=>'군복무', other=>'기타');
 sub career_types { return keys %CAREER_TYPE; }
 
 sub get_career {
     my ($self, $uid) = @_;
-    my $sql = qq(SELECT c.career_id, c.type, c.organization_id, COALESCE(o.name,'(삭제된 기관)') AS organization, c.position, date_format(c.start_date,'%Y-%m') AS start_date, date_format(c.end_date,'%Y-%m') AS end_date FROM bw_user_career c LEFT JOIN organizations o ON c.organization_id=o.org_id WHERE c.uid=? ORDER BY (c.end_date IS NULL) DESC, c.end_date DESC);
+    my $sql = qq(select c.career_id, c.type, c.organization_id,
+                        coalesce(o.name,'(삭제된 기관)') as organization, c.position,
+                        date_format(c.start_date,'%Y-%m') as start_date,
+                        date_format(c.end_date,'%Y-%m') as end_date
+                 from bw_user_career c left join organizations o on c.organization_id=o.org_id
+                 where c.uid=?
+                 order by (c.end_date is null) desc, c.end_date desc);
     my $rv = $DBH->selectall_arrayref($sql, {Slice=>{}}, $uid) || [];
     my $type = \%CAREER_TYPE;
     foreach my $r (@$rv) {
@@ -495,28 +503,32 @@ sub get_career {
 
 sub add_career {
     my ($self, $uid, $type, $org_id, $position, $s_date, $e_date) = @_;
-    my $sql = qq(INSERT INTO bw_user_career (uid,type,organization_id,position,start_date,end_date) VALUES (?,?,?,?,?,?));
+    my $sql = qq(insert into bw_user_career (uid, type, organization_id, position, start_date, end_date)
+                 values (?, ?, ?, ?, ?, ?));
     my $rv = $DBH->do($sql, undef, $uid, $type, $org_id, $position, $s_date, $e_date);
     return $rv;
 }
 
 sub update_career {
     my ($self, $career_id, $uid, $type, $org_id, $position, $s_date, $e_date) = @_;
-    my $sql = qq(UPDATE bw_user_career SET type=?,organization_id=?,position=?,start_date=?,end_date=? WHERE career_id=? && uid=?);
+    my $sql = qq(update bw_user_career
+                 set type=?, organization_id=?, position=?, start_date=?, end_date=?
+                 where career_id=? && uid=?);
     my $rv = $DBH->do($sql, undef, $type, $org_id, $position, $s_date, $e_date, $career_id, $uid);
     return $rv;
 }
 
 sub del_career {
     my ($self, $uid, $career_id) = @_;
-    my $sql = qq(DELETE FROM bw_user_career WHERE uid=? && career_id=?);
+    my $sql = qq(delete from bw_user_career where uid=? && career_id=?);
     my $rv = $DBH->do($sql, undef, $uid, $career_id);
     return $rv;
 }
 
 sub career_owned {
     my ($self, $career_id, $uid) = @_;
-    return $DBH->selectrow_array(qq(select 1 from bw_user_career where career_id=? && uid=?), undef, $career_id, $uid);
+    my $sql = qq(select 1 from bw_user_career where career_id=? && uid=?);
+    return $DBH->selectrow_array($sql, undef, $career_id, $uid);
 }
 
 sub career_set {
@@ -524,7 +536,11 @@ sub career_set {
     # inner join is deliberate: an orphaned career must NOT get an edit form, or a re-save
     # would resolve the '(삭제된 기관)' placeholder into a brand-new junk org. (get_career
     # LEFT JOINs for the read-only list; see its comment.)
-    my $sql = qq(SELECT c.career_id, c.type, c.organization_id, o.name AS organization, c.position, c.start_date, c.end_date FROM bw_user_career c JOIN organizations o ON c.organization_id=o.org_id WHERE c.uid=? ORDER BY (c.end_date IS NULL) DESC, c.end_date DESC);
+    my $sql = qq(select c.career_id, c.type, c.organization_id, o.name as organization,
+                        c.position, c.start_date, c.end_date
+                 from bw_user_career c join organizations o on c.organization_id=o.org_id
+                 where c.uid=?
+                 order by (c.end_date is null) desc, c.end_date desc);
     my $rv = $DBH->selectall_arrayref($sql, {Slice=>{}}, $uid) || [];
     my @rv;
     push @rv, { start_year=>$self->year_list, end_year=>$self->year_list, start_month=>$self->month_list, end_month=>$self->month_list };
@@ -554,12 +570,15 @@ sub org_suggest {
     $q =~ s/\s+$//;
     return [] unless length($q);
     # Names are stored HTML-escaped (house style, like degree department), so escape
-    # the query the same way BEFORE the prefix match — else a typed & / < / " never
+    # the query the same way BEFORE the prefix match -- else a typed & / < / " never
     # matches the stored &amp; / &lt; / &quot;. escapeHTML introduces no LIKE
     # metachars, so the LIKE-escape below still covers a literal % / _ / \ in $q.
     $q = $self->ui->cgi->escapeHTML($q);
     $q =~ s/([\\%_])/\\$1/g;
-    my $sql = qq(SELECT DISTINCT o.org_id, o.name FROM org_alias a JOIN organizations o ON a.org_id=o.org_id WHERE a.alias LIKE ? ORDER BY o.name LIMIT 10);
+    my $sql = qq(select distinct o.org_id, o.name
+                 from org_alias a join organizations o on a.org_id=o.org_id
+                 where a.alias like ?
+                 order by o.name limit 10);
     my $rv = $DBH->selectall_arrayref($sql, {Slice=>{}}, "$q%") || [];
     return $rv;
 }
@@ -569,14 +588,21 @@ sub resolve_or_create_org {
     $name ||= '';
     $name =~ s/^\s+//;
     $name =~ s/\s+$//;
-    return 0 unless length($name);
-    my $id = $DBH->selectrow_array(qq(SELECT a.org_id FROM org_alias a JOIN organizations o ON a.org_id=o.org_id WHERE a.alias=? LIMIT 1), undef, $name);
-    return $id if $id;
-    my $rv = $DBH->do(qq(INSERT INTO organizations (name,created_by) VALUES (?,?)), undef, $name, $uid);
-    return 0 unless $rv;
-    $id = $DBH->selectrow_array(qq(SELECT LAST_INSERT_ID()));
-    unless (defined $DBH->do(qq(INSERT INTO org_alias (alias,org_id) VALUES (?,?)), undef, $name, $id)) {
-        $DBH->do(qq(DELETE FROM organizations WHERE org_id=?), undef, $id);   # no alias == invisible org
+    return 0 unless (length($name));
+    my $sql = qq(select a.org_id
+                 from org_alias a join organizations o on a.org_id=o.org_id
+                 where a.alias=? limit 1);
+    my $id = $DBH->selectrow_array($sql, undef, $name);
+    return $id if ($id);
+    $sql = qq(insert into organizations (name, created_by) values (?, ?));
+    my $rv = $DBH->do($sql, undef, $name, $uid);
+    return 0 unless ($rv);
+    $sql = qq(select last_insert_id());
+    $id = $DBH->selectrow_array($sql);
+    $sql = qq(insert into org_alias (alias, org_id) values (?, ?));
+    unless (defined $DBH->do($sql, undef, $name, $id)) {
+        $sql = qq(delete from organizations where org_id=?);
+        $DBH->do($sql, undef, $id); # no alias == invisible org
         return 0;
     }
     return $id;
@@ -584,31 +610,41 @@ sub resolve_or_create_org {
 
 sub org_list {
     my ($self) = @_;
-    my $sql = qq(SELECT o.org_id,o.name, COUNT(DISTINCT c.career_id) AS usage_count, GROUP_CONCAT(DISTINCT a.alias ORDER BY a.alias SEPARATOR ', ') AS aliases FROM organizations o LEFT JOIN bw_user_career c ON c.organization_id=o.org_id LEFT JOIN org_alias a ON a.org_id=o.org_id GROUP BY o.org_id,o.name ORDER BY o.name);
+    my $sql = qq(select o.org_id, o.name, count(distinct c.career_id) as usage_count,
+                        group_concat(distinct a.alias order by a.alias separator ', ') as aliases
+                 from organizations o left join bw_user_career c on c.organization_id=o.org_id
+                      left join org_alias a on a.org_id=o.org_id
+                 group by o.org_id, o.name
+                 order by o.name);
     my $rv = $DBH->selectall_arrayref($sql, {Slice=>{}}) || [];
     return $rv;
 }
 
 sub org_exists {
     my ($self, $id) = @_;
-    my $sql = qq(SELECT 1 FROM organizations WHERE org_id=?);
+    my $sql = qq(select 1 from organizations where org_id=?);
     return $DBH->selectrow_array($sql, undef, $id);
 }
 
 sub org_merge {
     my ($self, $from, $to) = @_;
     return unless ($from && $to && $from =~ /^\d+$/ && $to =~ /^\d+$/ && $from != $to);
-    return unless $self->org_exists($to);
+    return unless ($self->org_exists($to));
     # No transactions on MyISAM: verify each step; never delete the org until the repoint
     # has emptied it, else orphaned careers lose their EDIT FORM via the inner join in
     # career_set (get_career now LEFT JOINs and shows them as '(삭제된 기관)'). The two
-    # trailing DELETEs are best-effort cleanup — careers are already repointed, and a stale
+    # trailing DELETEs are best-effort cleanup -- careers are already repointed, and a stale
     # alias can't misresolve because resolve_or_create_org's lookup joins organizations (G4).
-    return unless defined $DBH->do(qq(UPDATE bw_user_career SET organization_id=? WHERE organization_id=?), undef, $to, $from);
-    return if $DBH->selectrow_array(qq(SELECT COUNT(*) FROM bw_user_career WHERE organization_id=?), undef, $from);
-    return unless defined $DBH->do(qq(UPDATE IGNORE org_alias SET org_id=? WHERE org_id=?), undef, $to, $from);
-    $DBH->do(qq(DELETE FROM org_alias WHERE org_id=?), undef, $from);
-    $DBH->do(qq(DELETE FROM organizations WHERE org_id=?), undef, $from);
+    my $sql = qq(update bw_user_career set organization_id=? where organization_id=?);
+    return unless (defined $DBH->do($sql, undef, $to, $from));
+    $sql = qq(select count(*) from bw_user_career where organization_id=?);
+    return if ($DBH->selectrow_array($sql, undef, $from));
+    $sql = qq(update ignore org_alias set org_id=? where org_id=?);
+    return unless (defined $DBH->do($sql, undef, $to, $from));
+    $sql = qq(delete from org_alias where org_id=?);
+    $DBH->do($sql, undef, $from);
+    $sql = qq(delete from organizations where org_id=?);
+    $DBH->do($sql, undef, $from);
     return 1;
 }
 
@@ -619,8 +655,10 @@ sub org_add_alias {
     $alias =~ s/\s+$//;
     return unless ($org && $org =~ /^\d+$/ && $org > 0 && length($alias));
     $alias = $self->ui->cgi->escapeHTML($alias);
-    return '0E0' if $DBH->selectrow_array(qq(SELECT 1 FROM org_alias WHERE alias=? && org_id=?), undef, $alias, $org);
-    return $DBH->do(qq(INSERT INTO org_alias (alias,org_id) VALUES (?,?)), undef, $alias, $org);
+    my $sql = qq(select 1 from org_alias where alias=? && org_id=?);
+    return '0E0' if ($DBH->selectrow_array($sql, undef, $alias, $org));
+    $sql = qq(insert into org_alias (alias, org_id) values (?, ?));
+    return $DBH->do($sql, undef, $alias, $org);
 }
 
 sub org_del_alias {
@@ -630,10 +668,12 @@ sub org_del_alias {
     $alias =~ s/\s+$//;
     return unless ($org && $org =~ /^\d+$/ && $org > 0 && length($alias));
     $alias = $self->ui->cgi->escapeHTML($alias);
-    my $count = $DBH->selectrow_array(qq(SELECT COUNT(*) FROM org_alias WHERE org_id=?), undef, $org);
-    return unless defined $count;
-    return if $count <= 1;
-    my $rv = $DBH->do(qq(DELETE FROM org_alias WHERE org_id=? && alias=?), undef, $org, $alias);
+    my $sql = qq(select count(*) from org_alias where org_id=?);
+    my $count = $DBH->selectrow_array($sql, undef, $org);
+    return unless (defined $count);
+    return if ($count <= 1);
+    $sql = qq(delete from org_alias where org_id=? && alias=?);
+    my $rv = $DBH->do($sql, undef, $org, $alias);
     return $rv;
 }
 
@@ -885,7 +925,7 @@ sub get_guestbook_stat {
 # expect bw_xauth_passwd aliased as `a` in the outer query. Matching goes
 # through org_alias, so a search for any alias (e.g. Samsung) finds people
 # whose career is at the canonical org (삼성전자). The career column shows
-# ongoing orgs plus, as "(전) X", past orgs the keyword matched — so a hit on
+# ongoing orgs plus, as "(전) X", past orgs the keyword matched -- so a hit on
 # an ended career is visible. Career search is quid-pro-quo: the caller passes
 # has_career($viewer) and a viewer without it gets neither match nor display.
 my $CAREER_COL = qq((select group_concat(distinct o.name order by o.name separator ', ')

--- a/main/search2.cgi
+++ b/main/search2.cgi
@@ -17,7 +17,7 @@ unless ($auth->auth) {
 
 my ($type, $keyword, $page) = map { $ui->cparam($_) || '' } qw(type keyword page);
 $type = 'article' unless ($type);
-$page = '1' unless ($page =~ /^[1-9]\d*\z/);   # positive integer only: rendered as bare text in _search2_page_nav.tmpl and feeds the SQL LIMIT offset
+$page = '1' unless ($page =~ /^[1-9]\d*$/);   # positive integer only: rendered as bare text in _search2_page_nav.tmpl and feeds the SQL LIMIT offset
 
 if ($type && $type =~ /article|people|board/ && $keyword) {
 

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # =============================================================================
-# seed.pl — deterministic SYNTHETIC data seeder for the bawi test database
+# seed.pl -- deterministic SYNTHETIC data seeder for the bawi test database
 # =============================================================================
 # Fills the structure-only test schema with clean, obviously-fake data:
 # no real users, no PII, no production content. Every name/id/email/phone is
@@ -39,7 +39,7 @@
 #     bawi_access_stat, bw_note_notify_boxcar, bw_postman_log,
 #     bw_poll* (legacy), bw_xpoll_check, notes (legacy).
 #     Reseed truncates EVERY base table except schema_migrations (derived
-#     from information_schema, so it can't drift), then reseeds — no UI
+#     from information_schema, so it can't drift), then reseeds -- no UI
 #     experiment survives a "wipe + reseed".
 #     Deterministic caveat: columns with DEFAULT CURRENT_TIMESTAMP that the
 #     seeder leaves unset (bw_xboard_body.modified, bw_user_basic.modified,
@@ -63,7 +63,7 @@ my $pass = $ENV{BAWI_DB_PASS} || 'bawi-local-test-pw';
 # loading the schema; it only answers over the network after init (schema +
 # migrations) is complete, so "connects" == "ready to seed".
 my $dbh;
-for my $try (1 .. 90) {
+foreach my $try (1 .. 90) {
     $dbh = eval { DBI->connect("dbi:mysql:database=$name;host=$host", $user, $pass,
                                { RaiseError => 1, PrintError => 0 }) };
     last if $dbh;
@@ -82,8 +82,8 @@ sub d  { my $epoch = shift; return strftime('%Y-%m-%d', gmtime($epoch)) }
 # The app authenticates with  passwd = ENCRYPT(?, passwd)  server-side, so
 # server-side DES crypt MUST work. Fail loudly here rather than at login time.
 my $TEST_PASSWORD = 'test1234';   # (DES crypt only uses the first 8 chars)
-my ($pw_hash) = $dbh->selectrow_array(q{SELECT ENCRYPT(?, 'bw')}, undef, $TEST_PASSWORD);
-die "FATAL: MariaDB ENCRYPT() returned NULL — DES crypt unavailable in the db container; logins would be impossible\n"
+my ($pw_hash) = $dbh->selectrow_array(q(SELECT ENCRYPT(?, 'bw')), undef, $TEST_PASSWORD);
+die "FATAL: MariaDB ENCRYPT() returned NULL -- DES crypt unavailable in the db container; logins would be impossible\n"
     unless defined $pw_hash && length($pw_hash) == 13;
 print "password hash for '$TEST_PASSWORD': $pw_hash\n";
 
@@ -100,14 +100,14 @@ die "N_USERS must be >= 50 (later blocks hardcode uid ranges up to 50)\n" if $N_
 
 # ------------------------------------------------------------------- wipe
 # Truncate every base table except the migration ledger, so "wipe + reseed"
-# is true by construction — a hand-kept list drifts as migrations add tables
+# is true by construction -- a hand-kept list drifts as migrations add tables
 # (and already had: UI-writable tables were missing). No migration seeds
 # reference rows, so truncate-all is safe (per the migration runner's
 # CONTRACT header: rows a migration ships for prod must be mirrored here).
-my $tables = $dbh->selectcol_arrayref(q{
+my $tables = $dbh->selectcol_arrayref(q(
     SELECT table_name FROM information_schema.tables
     WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'
-      AND table_name <> 'schema_migrations'});
+      AND table_name <> 'schema_migrations'));
 print "truncating ", scalar(@$tables), " tables ...\n";
 $dbh->do("TRUNCATE TABLE `$_`") for @$tables;
 
@@ -116,20 +116,20 @@ print "seeding $N_USERS users (ids: root, tester02..tester$N_USERS; password: $T
 my %uname;   # uid -> display name
 my %uid2id;  # uid -> login id
 {
-    my $sth = $dbh->prepare(q{
+    my $sth = $dbh->prepare(q(
         INSERT INTO bw_xauth_passwd (uid, id, name, passwd, email, modified, accessed, access)
-        VALUES (?,?,?,?,?,?,?,?)});
-    my $ki  = $dbh->prepare(q{INSERT INTO bw_user_ki (uid, ki) VALUES (?,?)});
-    my $bas = $dbh->prepare(q{
+        VALUES (?,?,?,?,?,?,?,?)));
+    my $ki  = $dbh->prepare(q(INSERT INTO bw_user_ki (uid, ki) VALUES (?,?)));
+    my $bas = $dbh->prepare(q(
         INSERT INTO bw_user_basic (uid, ename, mobile_tel, birth, affiliation, title, greeting)
-        VALUES (?,?,?,?,?,?,?)});
-    my $acc = $dbh->prepare(q{INSERT INTO bw_user_access (uid, id, count) VALUES (?,?,?)});
+        VALUES (?,?,?,?,?,?,?)));
+    my $acc = $dbh->prepare(q(INSERT INTO bw_user_access (uid, id, count) VALUES (?,?,?)));
 
-    for my $uid (1 .. $N_USERS) {
+    foreach my $uid (1 .. $N_USERS) {
         my ($id, $nm);
         if ($uid == 1) { ($id, $nm) = ('root', '관리자테스트') }
         # 'tester%02d' = 8 chars: the app's id policy is 3-8 lowercase+digits
-        # and the login form enforces maxlength=8 — a longer synthetic id
+        # and the login form enforces maxlength=8 -- a longer synthetic id
         # could never log in through the real UI.
         else           { $id = sprintf('tester%02d', $uid); $nm = sprintf('테스트유저%02d', $uid) }
         $uid2id{$uid} = $id;
@@ -148,23 +148,23 @@ my %uid2id;  # uid -> login id
         );
         $acc->execute($uid, $id, 10 + $uid);
     }
-    my $sig = $dbh->prepare(q{INSERT INTO bw_user_sig (uid, sig) VALUES (?,?)});
+    my $sig = $dbh->prepare(q(INSERT INTO bw_user_sig (uid, sig) VALUES (?,?)));
     $sig->execute($_, "-- 테스트 서명 $_ (synthetic signature)") for 2 .. 10;
 }
 
 # ----------------------------------------------------------------- groups
 print "seeding 3 groups + memberships\n";
 {
-    my $g = $dbh->prepare(q{
+    my $g = $dbh->prepare(q(
         INSERT INTO bw_group (gid, pgid, title, keyword, uid, type, seq, created,
                               g_sub, m_sub, a_sub, g_board, m_board, a_board)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)});
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)));
     $g->execute(1, 0, '바위 테스트',   'bawitest',   1, 'open',   1, dt(BASE_EPOCH), 1,1,0,1,1,0);
     $g->execute(2, 1, '동호회 테스트', 'clubtest',   1, 'open',   2, dt(BASE_EPOCH), 1,1,0,1,1,0);
     $g->execute(3, 1, '비공개 테스트', 'closedtest', 1, 'closed', 3, dt(BASE_EPOCH), 0,1,0,0,1,0);
 
-    my $gu = $dbh->prepare(q{
-        INSERT INTO bw_group_user (gid, uid, status, created) VALUES (?,?,'active',?)});
+    my $gu = $dbh->prepare(q(
+        INSERT INTO bw_group_user (gid, uid, status, created) VALUES (?,?,'active',?)));
     $gu->execute(1, $_, dt(BASE_EPOCH + 3600 * $_)) for 1 .. $N_USERS;
     $gu->execute(2, $_, dt(BASE_EPOCH + 7200 * $_)) for 2 .. 21;
     $gu->execute(3, $_, dt(BASE_EPOCH + 9600 * $_)) for 2 .. 6;
@@ -182,12 +182,12 @@ my @BOARDS = (
 );
 print "seeding ", scalar(@BOARDS), " boards\n";
 {
-    my $b = $dbh->prepare(q{
+    my $b = $dbh->prepare(q(
         INSERT INTO bw_xboard_board
             (board_id, keyword, gid, title, uid, id, name, skin, seq, created,
              is_imgboard, a_read, a_write, a_comment)
-        VALUES (?,?,?,?,?,?,?,'default',?,?,?,?,0,0)});
-    for my $bd (@BOARDS) {
+        VALUES (?,?,?,?,?,?,?,'default',?,?,?,?,0,0)));
+    foreach my $bd (@BOARDS) {
         my ($bid, $kw, $gid, $title, $anon, $n) = @$bd;
         $b->execute($bid, $kw, $gid, $title, 1, 'root', $uname{1},
                     $bid, dt(BASE_EPOCH + 86400 * $bid), ($kw eq 'photo' ? 1 : 0), $anon);
@@ -201,19 +201,19 @@ my %first_article_id;        # board_id -> article_id of article_no 1
 my %poll_articles;           # article_id -> board_id (articles that get a poll)
 my @article_rows;            # [article_id, board_id, article_no, uid, created_epoch]
 {
-    my $h = $dbh->prepare(q{
+    my $h = $dbh->prepare(q(
         INSERT INTO bw_xboard_header
             (article_id, article_no, parent_no, thread_no, board_id, category,
              title, uid, id, name, count, recom, scrap, comments,
              has_attach, has_poll, created)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,0,0,0,0,?,?)});
-    my $bo = $dbh->prepare(q{
-        INSERT INTO bw_xboard_body (article_id, board_id, body) VALUES (?,?,?)});
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,0,0,0,0,?,?)));
+    my $bo = $dbh->prepare(q(
+        INSERT INTO bw_xboard_body (article_id, board_id, body) VALUES (?,?,?)));
 
-    for my $bd (@BOARDS) {
+    foreach my $bd (@BOARDS) {
         my ($bid, $kw, $gid, $btitle, $anon, $n) = @$bd;
         my @thread;                       # per-board stack of recent top-levels
-        for my $no (1 .. $n) {
+        foreach my $no (1 .. $n) {
             $article_id++;
             my $author  = 2 + (($article_id * 7) % ($N_USERS - 1));   # uid 2..50
             my $created = BASE_EPOCH + 86400 * 30 + $article_id * 3600 * 7;
@@ -229,7 +229,7 @@ my @article_rows;            # [article_id, board_id, article_no, uid, created_e
                 ? sprintf('Re: [테스트] %s 글 %03d', $btitle, $parent_no)
                 : sprintf('[테스트] %s 글 %03d — synthetic', $btitle, $no);
             # bw_xboard_header.title is char(64); this script has no `use utf8`,
-            # so length() counts BYTES — a blind substr could cut mid-Hangul.
+            # so length() counts BYTES -- a blind substr could cut mid-Hangul.
             # Titles are ours and deterministic: fail loudly instead.
             die "seed bug: title exceeds 64 bytes (shorten the board title in \@BOARDS): $title\n"
                 if length($title) > 64;
@@ -280,17 +280,17 @@ my @article_rows;            # [article_id, board_id, article_no, uid, created_e
 # --------------------------------------------------------------- comments
 print "seeding comments ...\n";
 {
-    my $c = $dbh->prepare(q{
+    my $c = $dbh->prepare(q(
         INSERT INTO bw_xboard_comment
             (comment_id, comment_no, board_id, article_id, body, uid, id, name, created)
-        VALUES (?,?,?,?,?,?,?,?,?)});
+        VALUES (?,?,?,?,?,?,?,?,?)));
     my $comment_id = 0;
     my %board_comment_no;                 # per-board running comment_no
-    for my $ar (@article_rows) {
+    foreach my $ar (@article_rows) {
         my ($aid, $bid, $no, $author, $created) = @$ar;
         next if $aid % 2;                 # every 2nd article gets comments
         my $n = 1 + ($aid % 4);           # 1..4 comments
-        for my $k (1 .. $n) {
+        foreach my $k (1 .. $n) {
             $comment_id++;
             my $cno = ++$board_comment_no{$bid};
             my $cuid = 2 + (($aid * 3 + $k * 11) % ($N_USERS - 1));
@@ -306,13 +306,13 @@ print "seeding comments ...\n";
 # ------------------------------------------------------- recommendations
 print "seeding recommendations ...\n";
 {
-    my $r = $dbh->prepare(q{
-        INSERT INTO bw_xboard_recom (uid, article_id, rectime) VALUES (?,?,?)});
+    my $r = $dbh->prepare(q(
+        INSERT INTO bw_xboard_recom (uid, article_id, rectime) VALUES (?,?,?)));
     my $n = 0;
-    for my $ar (@article_rows) {
+    foreach my $ar (@article_rows) {
         my ($aid, $bid, $no, $author, $created) = @$ar;
         my $k = $aid % 6;                 # 0..5 recommendations
-        for my $i (1 .. $k) {
+        foreach my $i (1 .. $k) {
             $r->execute(1 + $i, $aid, dt($created + 3600 + 60 * $i));  # uids 2..6
             $n++;
         }
@@ -323,15 +323,15 @@ print "seeding recommendations ...\n";
 # ------------------------------------------------------ notices, bookmarks
 print "seeding notices + bookmarks\n";
 {
-    my $nt = $dbh->prepare(q{INSERT INTO bw_xboard_notice (board_id, article_id) VALUES (?,?)});
+    my $nt = $dbh->prepare(q(INSERT INTO bw_xboard_notice (board_id, article_id) VALUES (?,?)));
     $nt->execute($_->[0], $first_article_id{$_->[0]}) for @BOARDS;
 
-    my $bm = $dbh->prepare(q{
+    my $bm = $dbh->prepare(q(
         INSERT INTO bw_xboard_bookmark (uid, board_id, article_no, comment_no, seq)
-        VALUES (?,?,?,?,?)});
-    for my $uid (1 .. 10) {
+        VALUES (?,?,?,?,?)));
+    foreach my $uid (1 .. 10) {
         my $seq = 0;
-        for my $bid (1, 2, 3, 4, 6) {
+        foreach my $bid (1, 2, 3, 4, 6) {
             # last-read position a bit behind the tip -> "new article" markers
             my ($board) = grep { $_->[0] == $bid } @BOARDS;
             my $max_no  = $board->[5];             # articles column of @BOARDS
@@ -345,10 +345,10 @@ print "seeding notices + bookmarks\n";
 # ------------------------------------------------------------------ notes
 print "seeding 40 notes\n";
 {
-    my $n = $dbh->prepare(q{
+    my $n = $dbh->prepare(q(
         INSERT INTO bw_note (msg_id, to_id, to_name, from_id, from_name, msg, sent_time, read_time)
-        VALUES (?,?,?,?,?,?,?,?)});
-    for my $i (0 .. 39) {
+        VALUES (?,?,?,?,?,?,?,?)));
+    foreach my $i (0 .. 39) {
         my $from = 1 + ($i % 10);
         my $to   = 1 + (($i + 3) % 10);
         my $sent = BASE_EPOCH + 86400 * 400 + $i * 10800;
@@ -364,55 +364,55 @@ print "seeding 40 notes\n";
 # ------------------------------------------------------------ article polls
 print "seeding 2 article polls\n";
 {
-    my $p  = $dbh->prepare(q{
+    my $p  = $dbh->prepare(q(
         INSERT INTO bw_xboard_poll (poll_id, board_id, article_id, poll, created, closed)
-        VALUES (?,?,?,?,?,?)});
-    my $po = $dbh->prepare(q{
-        INSERT INTO bw_xboard_poll_opt (opt_id, poll_id, opt, count) VALUES (?,?,?,?)});
-    my $pa = $dbh->prepare(q{
-        INSERT INTO bw_xboard_poll_ans (poll_id, uid, opt_id) VALUES (?,?,?)});
+        VALUES (?,?,?,?,?,?)));
+    my $po = $dbh->prepare(q(
+        INSERT INTO bw_xboard_poll_opt (opt_id, poll_id, opt, count) VALUES (?,?,?,?)));
+    my $pa = $dbh->prepare(q(
+        INSERT INTO bw_xboard_poll_ans (poll_id, uid, opt_id) VALUES (?,?,?)));
 
     my ($poll_id, $opt_id) = (0, 0);
-    for my $aid (sort { $a <=> $b } keys %poll_articles) {
+    foreach my $aid (sort { $a <=> $b } keys %poll_articles) {
         $poll_id++;
         my $bid = $poll_articles{$aid};
         $p->execute($poll_id, $bid, $aid, "테스트 설문 $poll_id (synthetic poll)",
                     dt(BASE_EPOCH + 86400 * 200), dt(BASE_EPOCH + 86400 * 900));
         my @opts;
-        for my $o (1 .. 3) {
+        foreach my $o (1 .. 3) {
             $opt_id++;
             push @opts, $opt_id;
             $po->execute($opt_id, $poll_id, "보기 $o (option $o)", 0);
         }
-        for my $u (2 .. 13) {                       # 12 voters
+        foreach my $u (2 .. 13) {                       # 12 voters
             my $choice = $opts[$u % 3];
             $pa->execute($poll_id, $u, $choice);
         }
     }
-    $dbh->do(q{UPDATE bw_xboard_poll_opt o
+    $dbh->do(q(UPDATE bw_xboard_poll_opt o
                SET count = (SELECT COUNT(*) FROM bw_xboard_poll_ans a
-                            WHERE a.opt_id = o.opt_id)});
+                            WHERE a.opt_id = o.opt_id)));
 }
 
 # --------------------------------------------------------------- xpoll (survey)
 print "seeding 1 survey (bw_xpoll)\n";
 {
-    $dbh->do(q{INSERT INTO bw_xpoll
+    $dbh->do(q(INSERT INTO bw_xpoll
         (poll_id, uid, name, id, dt_start, dt_end, opt_hide, numofq,
          poll_title, poll_txt, lk, participant, poll_comment)
         VALUES (1, 'root', ?, 'root', ?, ?, 0, 2,
-                '테스트 설문조사 (synthetic)', '테스트용 설문입니다.', 0, 12, '')},
+                '테스트 설문조사 (synthetic)', '테스트용 설문입니다.', 0, 12, '')),
         undef, $uname{1}, d(BASE_EPOCH + 86400 * 380), d(BASE_EPOCH + 86400 * 900));
-    my $q = $dbh->prepare(q{
-        INSERT INTO bw_xpoll_question (question_id, question_txt, poll_id) VALUES (?,?,1)});
+    my $q = $dbh->prepare(q(
+        INSERT INTO bw_xpoll_question (question_id, question_txt, poll_id) VALUES (?,?,1)));
     $q->execute(1, '테스트 질문 1 (synthetic question 1)');
     $q->execute(2, '테스트 질문 2 (synthetic question 2)');
-    my $c = $dbh->prepare(q{
+    my $c = $dbh->prepare(q(
         INSERT INTO bw_xpoll_choice (choice_id, question_id, choice_txt, choice_count, choice_q)
-        VALUES (?,?,?,?,?)});
+        VALUES (?,?,?,?,?)));
     my $cid = 0;
-    for my $qid (1, 2) {
-        for my $o (1 .. 3) {
+    foreach my $qid (1, 2) {
+        foreach my $o (1 .. 3) {
             $cid++;
             $c->execute($cid, $qid, "선택지 $o (choice $o)", ($o == 1 ? 6 : ($o == 2 ? 4 : 2)), $qid);
         }
@@ -422,14 +422,14 @@ print "seeding 1 survey (bw_xpoll)\n";
 # ------------------------------------------------- registration lookup data
 print "seeding registration lookups (countries/schools/majors/circles/registers)\n";
 {
-    my $co = $dbh->prepare(q{INSERT INTO countries (id, name, code) VALUES (?,?,?)});
+    my $co = $dbh->prepare(q(INSERT INTO countries (id, name, code) VALUES (?,?,?)));
     $co->execute(1, '대한민국', 'KR');
     $co->execute(2, 'United States', 'US');
     $co->execute(3, 'Japan', 'JP');
     $co->execute(4, 'Canada', 'CA');
 
-    my $sc = $dbh->prepare(q{
-        INSERT INTO schools (id, full_name, brief_name, url, country_code) VALUES (?,?,?,?,?)});
+    my $sc = $dbh->prepare(q(
+        INSERT INTO schools (id, full_name, brief_name, url, country_code) VALUES (?,?,?,?,?)));
     my @schools = (
         [1, '가상대학교',            '가상대',    'https://example.invalid/u1', 'KR'],
         [2, '모의과학기술원',        '모의과기원','https://example.invalid/u2', 'KR'],
@@ -440,22 +440,22 @@ print "seeding registration lookups (countries/schools/majors/circles/registers)
     );
     $sc->execute(@$_) for @schools;
 
-    my $mj = $dbh->prepare(q{INSERT INTO majors (id, parent_id, name) VALUES (?,?,?)});
-    my $dm = $dbh->prepare(q{INSERT INTO bw_data_major (major_id, parent_id, major) VALUES (?,?,?)});
+    my $mj = $dbh->prepare(q(INSERT INTO majors (id, parent_id, name) VALUES (?,?,?)));
+    my $dm = $dbh->prepare(q(INSERT INTO bw_data_major (major_id, parent_id, major) VALUES (?,?,?)));
     my @majors = ([1,0,'자연과학'],[2,0,'공학'],[3,1,'수학'],[4,1,'물리학'],
                   [5,1,'생물학'],[6,2,'전산학'],[7,2,'전자공학'],[8,2,'기계공학']);
-    for my $m (@majors) { $mj->execute(@$m); $dm->execute(@$m) }
+    foreach my $m (@majors) { $mj->execute(@$m); $dm->execute(@$m) }
 
-    my $ci = $dbh->prepare(q{INSERT INTO circles (id, name) VALUES (?,?)});
+    my $ci = $dbh->prepare(q(INSERT INTO circles (id, name) VALUES (?,?)));
     $ci->execute(1, '가상산악회'); $ci->execute(2, '모의사진반');
     $ci->execute(3, '테스트합창단'); $ci->execute(4, '샘플바둑부');
 
     # registers: fake alumni roster rows for exercising reg/register.cgi.
     # pins are clearly fake (9xxxxxxx); rows 1-5 already linked to test uids.
-    my $rg = $dbh->prepare(q{
+    my $rg = $dbh->prepare(q(
         INSERT INTO registers (id, pin, ki, name, born_on, category, remarks, uid, member_status)
-        VALUES (?,?,?,?,?,'졸업','synthetic',?,?)});
-    for my $i (1 .. 30) {
+        VALUES (?,?,?,?,?,'졸업','synthetic',?,?)));
+    foreach my $i (1 .. 30) {
         my $uid = $i <= 5 ? 45 + $i : undef;
         $rg->execute($i, 90000000 + $i, 10 + ($i % 25),
                      sprintf('가상졸업생%02d', $i),
@@ -471,13 +471,13 @@ print "seeding degrees / majors / circles per user\n";
     # status vocabulary lives in app code, not the schema (varchar):
     # Bawi::User::get_degree maps exactly these five to display labels.
     my @statuses = ('graduated','course_completed','admitted','other');
-    my $dg = $dbh->prepare(q{
+    my $dg = $dbh->prepare(q(
         INSERT INTO bw_user_degree
             (degree_id, uid, type, school_id, department, advisors, content,
              start_date, end_date, status)
-        VALUES (?,?,?,?,?,?,?,?,?,?)});
+        VALUES (?,?,?,?,?,?,?,?,?,?)));
     my $did = 0;
-    for my $uid (2 .. 46) {
+    foreach my $uid (2 .. 46) {
         $did++;
         my $type    = $types[$uid % 6];   # all 6 bw_user_degree.type values (incl. the 20161225_add_career_enum.sql additions)
         my $start   = BASE_EPOCH - 86400 * 365 * (10 - $uid % 8);
@@ -489,22 +489,22 @@ print "seeding degrees / majors / circles per user\n";
                      $current ? '1001-01-01' : d($start + 86400 * 365 * 4),
                      $current ? 'attending' : $statuses[$uid % 4]);
     }
-    my $um = $dbh->prepare(q{INSERT INTO bw_user_major (uid, major_id) VALUES (?,?)});
+    my $um = $dbh->prepare(q(INSERT INTO bw_user_major (uid, major_id) VALUES (?,?)));
     $um->execute($_, 3 + ($_ % 6)) for 2 .. 41;     # child majors 3..8
-    my $uc = $dbh->prepare(q{INSERT INTO bw_user_circle (uid, circle_id) VALUES (?,?)});
+    my $uc = $dbh->prepare(q(INSERT INTO bw_user_circle (uid, circle_id) VALUES (?,?)));
     $uc->execute($_, 1 + ($_ % 4)) for 2 .. 20;
 }
 
 # ------------------------------------------------------------ career (v3.2)
 print "seeding career entries (organizations / org_alias / bw_user_career)\n";
 {
-    my $org = $dbh->prepare(q{
-        INSERT INTO organizations (org_id, name, created_by) VALUES (?,?,1)});
-    my $al  = $dbh->prepare(q{INSERT INTO org_alias (alias, org_id) VALUES (?,?)});
+    my $org = $dbh->prepare(q(
+        INSERT INTO organizations (org_id, name, created_by) VALUES (?,?,1)));
+    my $al  = $dbh->prepare(q(INSERT INTO org_alias (alias, org_id) VALUES (?,?)));
     # App invariant (Bawi::User::resolve_or_create_org): the canonical name
-    # is ALWAYS also an alias — "no alias == invisible org". Keep each name
+    # is ALWAYS also an alias -- "no alias == invisible org". Keep each name
     # in its list. Names are stored HTML-ESCAPED (house style; org_suggest
-    # escapes the query before matching) — org 5 carries a literal & as
+    # escapes the query before matching) -- org 5 carries a literal & as
     # &amp; to keep that storage class exercised.
     my @ORGS = (        # org_id, canonical name, searchable aliases
         [1, '가상연구소 (Synthetic Labs)', ['가상연구소 (Synthetic Labs)', '가상연구소', 'Synthetic Labs']],
@@ -513,18 +513,18 @@ print "seeding career entries (organizations / org_alias / bw_user_career)\n";
         [4, 'Test Foundation',             ['Test Foundation', '테스트재단']],
         [5, 'Example &amp; Sons',          ['Example &amp; Sons', '예제앤선즈']],
     );
-    for my $o (@ORGS) {
+    foreach my $o (@ORGS) {
         my ($oid, $oname, $aliases) = @$o;
         $org->execute($oid, $oname);
         $al->execute($_, $oid) for @$aliases;
     }
     my @ctypes = ('employment','internship','volunteer','research','military','other');
-    my $cr = $dbh->prepare(q{
+    my $cr = $dbh->prepare(q(
         INSERT INTO bw_user_career
             (career_id, uid, type, organization_id, position, start_date, end_date)
-        VALUES (?,?,?,?,?,?,?)});
+        VALUES (?,?,?,?,?,?,?)));
     my $cid = 0;
-    for my $uid (2 .. 25) {              # 24 entries; full type-enum coverage
+    foreach my $uid (2 .. 25) {              # 24 entries; full type-enum coverage
         $cid++;
         my $start   = BASE_EPOCH - 86400 * 365 * (6 - $uid % 5);
         my $ongoing = $uid % 4 == 0;     # NULL end_date = ongoing
@@ -543,9 +543,9 @@ print "seeding career entries (organizations / org_alias / bw_user_career)\n";
 
 # ------------------------------------------------------------------- loads
 {
-    my $ld = $dbh->prepare(q{
-        INSERT INTO loads (id, one, five, fifteen, online, created_at) VALUES (?,?,?,?,?,?)});
-    for my $i (1 .. 24) {
+    my $ld = $dbh->prepare(q(
+        INSERT INTO loads (id, one, five, fifteen, online, created_at) VALUES (?,?,?,?,?,?)));
+    foreach my $i (1 .. 24) {
         $ld->execute($i, 0.1 + 0.01 * ($i % 7), 0.2, 0.15, 3 + $i % 9,
                      dt(BASE_EPOCH + 86400 * 500 + 3600 * $i));
     }
@@ -553,34 +553,34 @@ print "seeding career entries (organizations / org_alias / bw_user_career)\n";
 
 # --------------------------------------- derived counters (kept consistent)
 print "updating derived counters (board/article aggregates, stat tables)\n";
-$dbh->do(q{UPDATE bw_xboard_header h
+$dbh->do(q(UPDATE bw_xboard_header h
            SET comments = (SELECT COUNT(*) FROM bw_xboard_comment c
-                           WHERE c.article_id = h.article_id)});
-$dbh->do(q{UPDATE bw_xboard_header h
+                           WHERE c.article_id = h.article_id)));
+$dbh->do(q(UPDATE bw_xboard_header h
            SET recom = (SELECT COUNT(*) FROM bw_xboard_recom r
-                        WHERE r.article_id = h.article_id)});
-$dbh->do(q{UPDATE bw_xboard_board b SET
+                        WHERE r.article_id = h.article_id)));
+$dbh->do(q(UPDATE bw_xboard_board b SET
            articles       = (SELECT COUNT(*)             FROM bw_xboard_header  h WHERE h.board_id = b.board_id),
            max_article_no = (SELECT COALESCE(MAX(h.article_no),0) FROM bw_xboard_header  h WHERE h.board_id = b.board_id),
-           max_comment_no = (SELECT COALESCE(MAX(c.comment_no),0) FROM bw_xboard_comment c WHERE c.board_id = b.board_id)});
+           max_comment_no = (SELECT COALESCE(MAX(c.comment_no),0) FROM bw_xboard_comment c WHERE c.board_id = b.board_id)));
 
 # stat tables (hot/stat pages) aggregated from the seeded data
-$dbh->do(q{INSERT INTO bw_xboard_stat_board (board_id, counts, articles, comments, recoms)
+$dbh->do(q(INSERT INTO bw_xboard_stat_board (board_id, counts, articles, comments, recoms)
            SELECT board_id, SUM(count), COUNT(*), SUM(comments), SUM(recom)
-           FROM bw_xboard_header GROUP BY board_id});
-$dbh->do(q{INSERT INTO bw_xboard_stat_article
+           FROM bw_xboard_header GROUP BY board_id));
+$dbh->do(q(INSERT INTO bw_xboard_stat_article
                (board_id, article_id, title, id, name, count, recom, comments, created, ki)
            SELECT h.board_id, h.article_id, h.title, h.id, h.name,
                   h.count, h.recom, h.comments, h.created, COALESCE(k.ki, 0)
            FROM bw_xboard_header h LEFT JOIN bw_user_ki k ON k.uid = h.uid
-           ORDER BY h.recom DESC, h.article_id LIMIT 30});
-$dbh->do(q{INSERT INTO bw_xboard_stat_user (id, name, articles, counts, comments, recoms)
+           ORDER BY h.recom DESC, h.article_id LIMIT 30));
+$dbh->do(q(INSERT INTO bw_xboard_stat_user (id, name, articles, counts, comments, recoms)
            SELECT h.id, h.name, COUNT(*), SUM(h.count), SUM(h.comments), SUM(h.recom)
-           FROM bw_xboard_header h GROUP BY h.id, h.name});
+           FROM bw_xboard_header h GROUP BY h.id, h.name));
 
 # -------------------------------------------------------------- verification
 print "\n=== verification ===\n";
-for my $t (qw(bw_xauth_passwd bw_user_ki bw_group bw_group_user bw_xboard_board
+foreach my $t (qw(bw_xauth_passwd bw_user_ki bw_group bw_group_user bw_xboard_board
               bw_xboard_header bw_xboard_body bw_xboard_comment bw_xboard_recom
               bw_xboard_notice bw_xboard_bookmark bw_note bw_xboard_poll
               bw_xboard_poll_opt bw_xboard_poll_ans bw_user_degree registers
@@ -589,15 +589,15 @@ for my $t (qw(bw_xauth_passwd bw_user_ki bw_group bw_group_user bw_xboard_board
     printf "  %-22s %6d rows\n", $t, $n;
 }
 my ($login_ok) = $dbh->selectrow_array(
-    q{SELECT COUNT(*) FROM bw_xauth_passwd WHERE passwd = ENCRYPT(?, passwd)},
+    q(SELECT COUNT(*) FROM bw_xauth_passwd WHERE passwd = ENCRYPT(?, passwd)),
     undef, $TEST_PASSWORD);
 print "  users whose password verifies as '$TEST_PASSWORD': $login_ok (expect $N_USERS)\n";
 die "FATAL: seeded passwords do not verify\n" unless $login_ok == $N_USERS;
 
-my ($orphan_bodies) = $dbh->selectrow_array(q{
+my ($orphan_bodies) = $dbh->selectrow_array(q(
     SELECT COUNT(*) FROM bw_xboard_header h
     LEFT JOIN bw_xboard_body b ON b.article_id = h.article_id
-    WHERE b.article_id IS NULL});
+    WHERE b.article_id IS NULL));
 print "  headers without body: $orphan_bodies (expect 0)\n";
 die "FATAL: headers without bodies\n" if $orphan_bodies;
 

--- a/t/markdown_smoke.pl
+++ b/t/markdown_smoke.pl
@@ -134,22 +134,22 @@ $body = render('$$<script>alert(1)</script>$$');
 
 # ```lang fence -> <pre><code class="language-..."> with entities escaped,
 # and $ inside code never becomes math
-$body = render(qq{```perl\nmy \$x = <STDIN>;\nprint "\$x & \$y";\n```});
+$body = render(qq(```perl\nmy \$x = <STDIN>;\nprint "\$x & \$y";\n```));
 &assert_contains('fence language class', $body, '<pre><code class="language-perl">');
 &assert_contains('fence escapes angle', $body, 'my $x = &lt;STDIN&gt;;');
 &assert_contains('fence escapes amp', $body, '&amp;');
 &assert_not_contains('fence dollar not math', $body, '\(');
 
 # bare fence -> plain <pre><code>
-$body = render(qq{```\nplain block\n```});
+$body = render(qq(```\nplain block\n```));
 &assert_contains('bare fence', $body, '<pre><code>plain block');
 
 # $$ inside a fence stays literal (MathJax skips <code>)
-$body = render(qq{```\n\$\$x\$\$\n```});
+$body = render(qq(```\n\$\$x\$\$\n```));
 &assert_contains('math in fence literal', $body, '$$x$$');
 
 # markdown markup inside a fence stays literal
-$body = render(qq{```\n# not a heading\n```});
+$body = render(qq(```\n# not a heading\n```));
 &assert_not_contains('heading in fence literal', $body, '<h1>');
 
 # --- pipe table fixtures ---
@@ -214,20 +214,20 @@ $body = render('허공[^nope] 참조');
 &assert_not_contains('no fn section', $body, 'class="footnotes"');
 
 # fn ref inside a fence stays literal
-$body = render(qq{```\n각주[^1] 문법\n```\n\n[^1]: 정의\n});
+$body = render(qq(```\n각주[^1] 문법\n```\n\n[^1]: 정의\n));
 &assert_contains('fn ref in fence literal', $body, '각주[^1] 문법');
 
 # --- blockquote nesting fixtures ---
 
 # fence inside a blockquote: quote prefix stripped from code, block stays
 # inside the quote
-$body = render(qq{> 인용 속 코드:\n>\n> ```python\n> def f(): pass\n> ```\n});
+$body = render(qq(> 인용 속 코드:\n>\n> ```python\n> def f(): pass\n> ```\n));
 &assert_contains('quoted fence class', $body, '<pre><code class="language-python">def f(): pass');
 die "quoted fence not inside blockquote:\n$body"
     unless $body =~ m{<blockquote>.*<pre><code class="language-python">.*</blockquote>}s;
 
 # code lines keeping their own > chars beyond the quote level
-$body = render(qq{> ```\n> cmd >> out.txt\n> ```\n});
+$body = render(qq(> ```\n> cmd >> out.txt\n> ```\n));
 &assert_contains('quoted fence redirect chars', $body, 'cmd &gt;&gt; out.txt');
 
 # table inside a blockquote
@@ -244,20 +244,20 @@ $body = render("> | a | b |\n> |---|---|\n> | 1 | 2 |\n| 3 | 4 |\n");
 
 # fence info strings beyond \w: c++/c# map to prism grammar names,
 # hyphenated tags pass through
-$body = render(qq{```c++\nint x = v.size();\n```});
+$body = render(qq(```c++\nint x = v.size();\n```));
 &assert_contains('c++ fence class', $body, '<pre><code class="language-cpp">int x = v.size();');
-$body = render(qq{```objective-c\nid obj;\n```});
+$body = render(qq(```objective-c\nid obj;\n```));
 &assert_contains('hyphenated fence class', $body, 'class="language-objective-c"');
 
 # fences are no longer <p>-wrapped (tables already were not)
-$body = render(qq{```\nplain\n```});
+$body = render(qq(```\nplain\n```));
 &assert_not_contains('fence not p-wrapped', $body, '<p><pre');
-$body = render(qq{> ```\n> quoted\n> ```});
+$body = render(qq(> ```\n> quoted\n> ```));
 &assert_not_contains('quoted fence not p-wrapped', $body, '<p><pre');
 
 # an unbalanced $$ stays literal: the fence after it survives and
 # blocks in between keep their structure
-$body = render(qq{비용은 \$\$ 큽니다.\n\n## 소제목\n\n```perl\nmy \$x;\n```\n});
+$body = render(qq(비용은 \$\$ 큽니다.\n\n## 소제목\n\n```perl\nmy \$x;\n```\n));
 &assert_contains('unbalanced dollars keep heading', $body, '<h2>소제목</h2>');
 &assert_contains('unbalanced dollars keep fence', $body, '<pre><code class="language-perl">');
 &assert_not_contains('no leaked sentinel bytes', $body, "\x{1A}");
@@ -289,7 +289,7 @@ $body = render("위조 \x{1A}M0M\x{1A} 토큰과 \$x\$ 수식");
 
 # javascript: URLs DISPLAYED inside a fence stay verbatim (quotes are
 # entity-escaped, so the href strip cannot rewrite them)
-$body = render(qq{```html\n<a href="javascript:alert(1)">x</a>\n```});
+$body = render(qq(```html\n<a href="javascript:alert(1)">x</a>\n```));
 &assert_contains('js url in fence displayed', $body, 'href=&quot;javascript:alert(1)&quot;');
 &assert_not_contains('js url in fence not stripped', $body, 'href="#"');
 
@@ -396,9 +396,9 @@ $body = render('<pre>~~a~~ <code>b</code> ~~c~~</pre>');
 &assert_not_contains('pre-nested-code no del', $body, '<del>');
 
 # c++ / c# fences map to prism's canonical grammar names
-$body = render(qq{```c++\nint x;\n```});
+$body = render(qq(```c++\nint x;\n```));
 &assert_contains('cpp alias class', $body, '<pre><code class="language-cpp">');
-$body = render(qq{```c#\nint x;\n```});
+$body = render(qq(```c#\nint x;\n```));
 &assert_contains('csharp alias class', $body, '<pre><code class="language-csharp">');
 
 # --- render cache preconditions (Board.pm's bw_xboard_body_html rows) ---
@@ -543,7 +543,7 @@ $body = render(qq{```c#\nint x;\n```});
         # is in the LAST <CAP bytes still runs, but is budget+CAP bounded
         'residual-tail'   => ("word " x 12000) . "\n" . ("<x a=" x 800),
     );
-    for my $name (sort keys %flood) {
+    foreach my $name (sort keys %flood) {
         my $t0 = time;
         render($flood{$name});
         die sprintf("block-opener DoS regression [%s]: %.2fs (expected <2)\n",

--- a/user/career.cgi
+++ b/user/career.cgi
@@ -48,10 +48,10 @@ $org =~ s/^\s+|\s+$//g;  $position =~ s/^\s+|\s+$//g;
 # 1001 (year) / 00 (month) = the '현재' sentinel emitted by year_list/month_list; it
 # means "no date" and maps to SQL NULL below (never a 1001-01-01 row).
 my $this_year = (localtime)[5] + 1900;
-$s_year = '' unless ($s_year eq '1001' || ($s_year =~ /\A\d{4}\z/ && $s_year >= 1991 && $s_year <= $this_year));
-$e_year = '' unless ($e_year eq '1001' || ($e_year =~ /\A\d{4}\z/ && $e_year >= 1991 && $e_year <= $this_year));
-$s_month = '' unless ($s_month =~ /\A(00|0[1-9]|1[0-2])\z/);
-$e_month = '' unless ($e_month =~ /\A(00|0[1-9]|1[0-2])\z/);
+$s_year = '' unless ($s_year eq '1001' || ($s_year =~ /^\d{4}$/ && $s_year >= 1991 && $s_year <= $this_year));
+$e_year = '' unless ($e_year eq '1001' || ($e_year =~ /^\d{4}$/ && $e_year >= 1991 && $e_year <= $this_year));
+$s_month = '' unless ($s_month =~ /^(00|0[1-9]|1[0-2])$/);
+$e_month = '' unless ($e_month =~ /^(00|0[1-9]|1[0-2])$/);
 
 my $s_date;
 if ($s_year && $s_year ne '1001') {

--- a/user/skin/default/_html_header.tmpl
+++ b/user/skin/default/_html_header.tmpl
@@ -3,7 +3,8 @@
 <head>
 <title><tmpl_if HTMLTitle><tmpl_var HTMLTitle></tmpl_if></title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<link href="<tmpl_var user_url>/skin/default/default.css" rel="stylesheet" type="text/css">
+<!-- ?v= busts the browser CSS cache; bump the token whenever default.css changes -->
+<link href="<tmpl_var user_url>/skin/default/default.css?v=20260729" rel="stylesheet" type="text/css">
 <tmpl_if skin></tmpl_if>
 <link rel="shortcut icon" href="/favicon.ico" >
 <style type="text/css">

--- a/user/skin/default/career.tmpl
+++ b/user/skin/default/career.tmpl
@@ -5,13 +5,6 @@
 <div style="background:#FFC129; padding: 0px; text-align: center; -webkit-border-radius: 6px; -moz-border-radius: 6px"><tmpl_var msg></div>
 </tmpl_if>
 
-<style type="text/css">
-.org-wrap { position:relative; }
-.org-suggest { display:none; position:absolute; left:0; top:22px; width:446px; border:1px solid #999; background:#fff; z-index:20; }
-.org-suggest div { padding:2px 4px; cursor:pointer; }
-.org-suggest div.on { background:#FFC129; }
-</style>
-
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
 <tr>
     <td class="iteml" width="105">

--- a/user/skin/default/default.css
+++ b/user/skin/default/default.css
@@ -393,3 +393,28 @@ div#bxmenu {
     width: 175px;
     float: left;
     }
+
+/* career.cgi */
+.org-wrap {
+    position: relative;
+    }
+
+.org-suggest {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 22px;
+    width: 446px;
+    border: 1px solid #999;
+    background: #fff;
+    z-index: 20;
+    }
+
+.org-suggest div {
+    padding: 2px 4px;
+    cursor: pointer;
+    }
+
+.org-suggest div.on {
+    background: #FFC129;
+    }

--- a/user/upload_photo.cgi
+++ b/user/upload_photo.cgi
@@ -51,7 +51,10 @@ if($q->param('image')) {
     # ImageMagick picks its coder by file content, not the .jpg name, so a forged
     # image/jpeg carrying SVG/MVG/MSL bytes would be parsed by the vulnerable
     # delegate (ImageTragick). Require a real JPEG SOI marker before Read().
-    open(my $sfh, '<', $temp_file); binmode($sfh); read($sfh, my $sig, 8); close($sfh);
+    open(my $sfh, '<', $temp_file);
+    binmode($sfh);
+    read($sfh, my $sig, 8);
+    close($sfh);
     if (Bawi::ImageSig::is_jpeg($sig)) {
         # Process with ImageMagick to strip metadata
         use Image::Magick;


### PR DESCRIPTION
## What

Mechanical style normalization of the code merged in PRs #5–#30, measured against the house style of the tree as promoted from production (`cfc414a`). A four-way sweep (Perl modules / board CGIs+templates / user-admin-main CGIs+templates / SQL+infra) found the merged code structurally faithful, with a consistent set of modern-Perl habits the baseline never uses. This PR normalizes those. **No behavior changes intended.**

Per review decision: **rationale comments documenting architectural/security invariants are kept** — only their typography (Unicode em-dashes → ASCII `--`) is normalized.

## Changes

- **lib/Bawi/User.pm** (career/org subs): lowercase SQL keywords (this file's 51:4 convention; Board.pm additions already correctly used its UPPERCASE convention), hoist inline `qq()` out of `$DBH->` calls into `my $sql = qq(...)` (house 153:0), wrap the 300+-char single-line SELECTs in the house aligned style, parenthesize postfix conditionals (house 127:1)
- `qq{}`/`q{}` → `qq()`/`q()` in Markdown.pm, seed.pl, t/markdown_smoke.pl (house: 409 `qq(`, zero brace forms; all 60 contents verified brace-free and paren-balanced)
- `for my` → `foreach my` (house 85:0)
- `\A…\z` anchors → `^…$` in user/career.cgi, main/search2.cgi (house uses `^…$` exclusively; career.cgi itself mixed both)
- **admin/organizations.cgi**: two-step `auth` + `is_admin` gate → the single `auth_admin`/`access_denied` idiom used by all three baseline admin tools
- **career.tmpl**: page-level `<style>` block moved to `user/skin/default/default.css` under a `/* career.cgi */` section (house convention). Since `.org-suggest{display:none}` is load-bearing, the user stylesheet link gains a `?v=` cache-bust token, mirroring the main-skin convention
- **ImageSig.pm**: add the missing `use warnings;` (every substantive baseline module has it)
- **upload_photo.cgi**: split the 4-statements-on-one-line signature read; the 3-arg lexical `open` is deliberately kept (safer than the legacy 2-arg bareword idiom)
- em-dashes → ASCII in source-file comments (board CGIs, docker files, conf headers); seeded Korean data strings in seed.pl keep theirs (that's content, not style)
- `mysql` → `mariadb` client in INSTALLATION.md and docker-compose comments (repo convention)

## Deliberately not changed

- `{Slice=>{}}` fetch idiom and Markdown.pm `_private` sub naming — internally consistent; changing them is behavioral churn
- `db/2026*` migrations — already applied on prod; conventions noted for future migrations instead
- seed.pl's UPPERCASE/unspaced SQL literals — dev-only tooling, delimiter fix only
- Comment density/content — kept by decision

## Verification

- `perl -c` clean on all touched modules/scripts (CGIs checked inside the docker web container)
- `t/markdown_smoke.pl` passes (exercises every delimiter-swapped path in Markdown.pm)
- Live checks against the docker test env: login → `career.cgi`, `organization.cgi?q=…` (suggest JSON incl. the HTML-escaped `&` org), `myarticle.cgi`, `mycomment.cgi`, `search2.cgi`, `admin/organizations.cgi` all 200 with expected content; write paths exercised end-to-end (career add with new-org auto-create → alias add → alias del with the count>1 guard → org merge repointing the career and cleaning up) — every rewritten SQL statement in User.pm ran against the live schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)