### PR TITLE
fix(news): closed-board titles/teasers no longer served to non-members (m_read filter, 6 sites)

### DIFF
--- a/main/news.cgi
+++ b/main/news.cgi
@@ -148,6 +148,13 @@ foreach my $i (@boards[7..8]) {
 }
 $t->param(box=>\@box);
 
+# m_read=1 (here and in $recent below) mirrors Group::authz: those boards
+# are readable by EVERY logged-in user (news.cgi is auth-gated), so their
+# titles/teasers on this global page leak nothing; m_read=0 boards are
+# group-gated and must never reach it. Viewer-independent by design: a
+# per-viewer membership join would cost a query per row for a page cached
+# in no way -- closed-group members browse their boards directly.
+#
 # The page shows a ~16-word teaser per article, so pull 1000 chars of body,
 # not the whole TEXT column, and cap the row count (was unbounded: every
 # qualifying article of the last 5 days, full body each, on every front-page
@@ -163,6 +170,7 @@ select a.title as board_title, b.board_id, b.article_id, b.title, b.id, b.name, 
 from bw_xboard_board as a, bw_xboard_stat_article as b, bw_xboard_body as c, bw_xauth_passwd as d
 where d.id = b.id && a.board_id=b.board_id && b.article_id=c.article_id
    && b.ki > 1 && b.created > date_sub(now(), interval 5 day)
+   && a.m_read = 1
 order by (score - expiry) desc limit 20);
 #my $hot = qq(select a.title as board_title, b.board_id, b.article_id, b.title, b.id, b.name, d.uid, date_format(b.created, '%m/%d') as created, round(b.count * 0.01 + b.recom * 3 + 10 * b.recom * 100 / ( b.count ) + b.comments * 0.3 ) as score from bw_xboard_board as a, bw_xboard_stat_article as b, bw_xboard_body as c, bw_xauth_passwd as d where d.id like b.id && a.board_id=b.board_id && b.article_id=c.article_id && b.ki > 1 order by score desc limit 10);
 
@@ -193,7 +201,7 @@ foreach my $i (sort { ($$hot_stat{$b}->{score} - $$hot_stat{$b}->{expiry})  <=> 
 
 $t->param(hot_stat=>\@hot_stat);
 
-my $board = qq(select a.title, b.board_id from bw_xboard_board as a, bw_xboard_stat_board as b where a.board_id=b.board_id and b.board_id != 688 order by round(b.articles * 3 + b.counts * 0.1 + b.recoms * 3 + (b.counts + b.comments * 5 + b.recoms * 50) / b.articles) desc limit 3);
+my $board = qq(select a.title, b.board_id from bw_xboard_board as a, bw_xboard_stat_board as b where a.board_id=b.board_id and a.m_read=1 and b.board_id != 688 order by round(b.articles * 3 + b.counts * 0.1 + b.recoms * 3 + (b.counts + b.comments * 5 + b.recoms * 50) / b.articles) desc limit 3);
 
 my $board_stat = $dbh->selectall_arrayref($board);
 my @board_stat = map { { title=>$$_[0], board_id=>$$_[1] } } @$board_stat;
@@ -210,7 +218,7 @@ my $gbook = $dbh->selectall_arrayref(qq(select a.ki, b.name, b.id, b.uid, count(
 my @gbook = map { { name=>$$_[1], id=>$$_[2], uid=>$$_[3] } } @$gbook;
 $t->param(gbook_stat=>\@gbook);
 
-my $nb = qq(select title, board_id, date_format(created, '%m/%d') as created, id, name from bw_xboard_board where created > date_sub(now(), interval 7 day) && articles > 0);
+my $nb = qq(select title, board_id, date_format(created, '%m/%d') as created, id, name from bw_xboard_board where m_read=1 && created > date_sub(now(), interval 7 day) && articles > 0);
 my $new_board = $dbh->selectall_hashref($nb, 'board_id');
 
 my @new_board = map { $$new_board{$_} } sort { $$new_board{$b}->{board_id} <=> $$new_board{$a}->{board_id} } keys %$new_board;
@@ -268,7 +276,7 @@ LEFT JOIN bw_xboard_header b
 ON t.article_id = b.article_id
 LEFT JOIN bw_xboard_board a
 ON a.board_id = b.board_id
-WHERE a.gid!=18 && a.is_anonboard=0 && a.allow_recom=1 
+WHERE a.gid!=18 && a.is_anonboard=0 && a.allow_recom=1 && a.m_read=1
 order by b.article_id desc limit 40;
 /;
 

--- a/main/sql/update_article_stat.sql
+++ b/main/sql/update_article_stat.sql
@@ -1,8 +1,9 @@
 delete from bw_xboard_stat_article;
 insert into bw_xboard_stat_article (board_id, article_id, title, id, name, count, recom, comments, created, ki)
   select a.board_id, a.article_id, a.title, a.id, a.name, a.count, a.recom, a.comments, a.created, count(distinct b.ki) as ki
-    from bw_xboard_header as a, bw_user_ki as b, bw_xboard_recom as c
+    from bw_xboard_header as a, bw_user_ki as b, bw_xboard_recom as c, bw_xboard_board as d
     where b.uid=c.uid && a.article_id=c.article_id 
+         && d.board_id=a.board_id && d.m_read=1
          && a.created >  date_sub(now(), interval 30 day)
          && a.recom > 2 
          && a.count > 20 && a.count < 4000 

--- a/main/sql/update_xboard_stat.sql
+++ b/main/sql/update_xboard_stat.sql
@@ -3,7 +3,7 @@ delete from bw_xboard_stat_board;
 insert into bw_xboard_stat_board (board_id, counts, articles, comments, recoms)
   select a.board_id, sum(count) as counts, count(b.article_id) as articles, sum(comments) as comments, sum(recom) as recoms
     from bw_xboard_board as a, bw_xboard_header as b
-      where a.board_id=b.board_id && a.board_id !=637 && a.board_id != 688 && b.created> date_sub(now(), interval 7 day)
+      where a.board_id=b.board_id && a.m_read=1 && a.board_id !=637 && a.board_id != 688 && b.created> date_sub(now(), interval 7 day)
         group by a.board_id order by counts desc;
 
 delete from bw_xboard_stat_user;

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -23,9 +23,11 @@
 #     bw_user_ki, bw_user_basic, bw_user_sig, bw_user_access,
 #     bw_group (3), bw_group_user, bw_xboard_board (7; board 7 is the
 #     closed-group privacy-canary board, see t/smoke.sh),
-#     bw_xboard_header/body (321 articles; 5 are category=1 markdown, to
+#     bw_xboard_header/body (322 articles; 5 are category=1 markdown, to
 #     exercise Bawi::Markdown + the bw_xboard_body_html render cache;
-#     article 321 is the closed-board canary),
+#     article 321 is the closed-board canary, 322 the open hot-channel
+#     control -- both carry NOW()-relative engagement, see the canary
+#     block),
 #     bw_xboard_comment (320),
 #     bw_xboard_notice, bw_xboard_recom, bw_xboard_bookmark, bw_note (41),
 #     bw_xboard_poll/_opt/_ans (2 article polls), bw_xpoll/_question/_choice
@@ -388,6 +390,7 @@ print "seeding privacy canaries (closed canary board, canary article + note)\n";
 use constant CANARY_ARTICLE => 'CANARY-ARTICLE-b7a2f9';
 use constant CANARY_TITLE   => 'CANARY-TITLE-c7d4e2';
 use constant CANARY_NOTE    => 'CANARY-NOTE-n5c3e1';
+use constant CANARY_CONTROL => 'CONTROL-HOT-a9d2c4';
 {
     my $cb = 1 + (sort { $b <=> $a } map { $_->[0] } @BOARDS)[0];  # next free board_id
     $dbh->do(q(
@@ -412,6 +415,41 @@ use constant CANARY_NOTE    => 'CANARY-NOTE-n5c3e1';
         dt(BASE_EPOCH + 86400 * 401));
     $dbh->do(q(INSERT INTO bw_xboard_body (article_id, board_id, body) VALUES (?, ?, ?)),
         undef, $ca, $cb, "이 글은 폐쇄 그룹 전용입니다.\n" . CANARY_ARTICLE . "\n(synthetic canary, members uid 2..6 only)");
+
+    # ---- engagement, for the front-page HOT/teaser channel tests ----
+    # The stat cron (main/sql/update_article_stat.sql) admits articles on
+    # recom>2 && count 21..3999 && created within 30 days; news.cgi's $hot
+    # additionally needs created within 5 days and >1 distinct recommender
+    # ki. Give the CLOSED canary qualifying engagement (recommenders =
+    # closed-group members uid 2..5, distinct ki by construction) so the
+    # cron's m_read=1 filter is what excludes it -- a live test, not a
+    # ranking accident. Seed an OPEN control article (board 2) with the
+    # same engagement plus a body token: it MUST come through the cron and
+    # the hot teaser (channel liveness / positive control for t/smoke.sh).
+    # Deterministic caveat: these two use NOW()-relative created dates --
+    # the hot window is wall-clock; everything else stays fixed-epoch.
+    $dbh->do(q(UPDATE bw_xboard_header
+               SET recom=5, count=50, created=DATE_SUB(NOW(), INTERVAL 2 HOUR)
+               WHERE article_id=?), undef, $ca);
+    my $rec = $dbh->prepare(q(
+        INSERT INTO bw_xboard_recom (uid, article_id, rectime) VALUES (?,?,NOW())));
+    $rec->execute($_, $ca) for 2 .. 5;
+
+    my $ctrl = ++$article_id;
+    my ($ctrl_no) = $dbh->selectrow_array(
+        q(SELECT COALESCE(MAX(article_no),0)+1 FROM bw_xboard_header WHERE board_id=2));
+    $dbh->do(q(
+        INSERT INTO bw_xboard_header
+            (article_id, article_no, parent_no, thread_no, board_id, category,
+             title, uid, id, name, count, recom, scrap, comments,
+             has_attach, has_poll, created)
+        VALUES (?, ?, 0, ?, 2, 0, ?, 3, ?, ?, 60, 6, 0, 0, 0, 0,
+                DATE_SUB(NOW(), INTERVAL 1 HOUR))),
+        undef, $ctrl, $ctrl_no, $ctrl_no, '핫 컨트롤 글 ' . CANARY_CONTROL,
+        $uid2id{3}, $uname{3});
+    $dbh->do(q(INSERT INTO bw_xboard_body (article_id, board_id, body) VALUES (?, 2, ?)),
+        undef, $ctrl, "공개 컨트롤 글입니다.\n" . CANARY_CONTROL . "\n(synthetic hot-channel control)");
+    $rec->execute($_, $ctrl) for 10 .. 13;
 
     my ($max_msg) = $dbh->selectrow_array(q(SELECT COALESCE(MAX(msg_id),0) FROM bw_note));
     $dbh->do(q(
@@ -629,13 +667,16 @@ $dbh->do(q(UPDATE bw_xboard_board b SET
 
 # stat tables (hot/stat pages) aggregated from the seeded data
 $dbh->do(q(INSERT INTO bw_xboard_stat_board (board_id, counts, articles, comments, recoms)
-           SELECT board_id, SUM(count), COUNT(*), SUM(comments), SUM(recom)
-           FROM bw_xboard_header GROUP BY board_id));
+           SELECT h.board_id, SUM(h.count), COUNT(*), SUM(h.comments), SUM(h.recom)
+           FROM bw_xboard_header h JOIN bw_xboard_board b ON b.board_id=h.board_id
+           WHERE b.m_read=1 GROUP BY h.board_id));
 $dbh->do(q(INSERT INTO bw_xboard_stat_article
                (board_id, article_id, title, id, name, count, recom, comments, created, ki)
            SELECT h.board_id, h.article_id, h.title, h.id, h.name,
                   h.count, h.recom, h.comments, h.created, COALESCE(k.ki, 0)
            FROM bw_xboard_header h LEFT JOIN bw_user_ki k ON k.uid = h.uid
+           JOIN bw_xboard_board b ON b.board_id = h.board_id
+           WHERE b.m_read = 1
            ORDER BY h.recom DESC, h.article_id LIMIT 30));
 $dbh->do(q(INSERT INTO bw_xboard_stat_user (id, name, articles, counts, comments, recoms)
            SELECT h.id, h.name, COUNT(*), SUM(h.count), SUM(h.comments), SUM(h.recom)

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -16,9 +16,10 @@
 #      cache), post, comment, logout
 #   3  privacy canaries: the closed-board article and the private note are
 #      served to who they belong to and to NOBODY else (logged-out,
-#      non-member, wrong member) -- EXCEPT the news.cgi title channel,
-#      deliberately pinned as a KNOWN leak until the app gains a
-#      membership filter (see that check). Seeded by seed/seed.pl ("privacy
+#      non-member, wrong member) -- including the front page, where the
+#      REAL stat crons are run against an engagement-qualifying closed
+#      canary (only the m_read filter keeps it out) with an open control
+#      article proving the channel live. Seeded by seed/seed.pl ("privacy
 #      canaries"); tokens: article BODY carries CANARY-ARTICLE-*, article
 #      TITLE carries CANARY-TITLE-* (title-rendering surfaces are a separate
 #      leak channel from body-rendering ones).
@@ -40,6 +41,7 @@ PASS='test1234'
 CANARY_ARTICLE='CANARY-ARTICLE-b7a2f9'
 CANARY_TITLE='CANARY-TITLE-c7d4e2'
 CANARY_NOTE='CANARY-NOTE-n5c3e1'
+CANARY_CONTROL='CONTROL-HOT-a9d2c4'
 
 # Port: compose reads the gitignored .env; a shell running this script does
 # not. Resolve like compose (env var wins, then .env, then 8080) so HTTP
@@ -273,41 +275,41 @@ got=$(db "SELECT COUNT(*) FROM bw_xboard_header WHERE board_id=$cbid AND title='
 [ "$got" = "0" ] || fail "LEAK: non-member wrote into the closed board (got '$got')"
 ok "non-member cannot post into the closed board"
 
-# The front page's hot-teaser (bodies) reads bw_xboard_stat_article, which
-# news.cgi joins WITHOUT a permission filter -- and prod's populator
-# (main/sql/update_article_stat.sql) admits rows on engagement alone, no
-# privacy clause, so on PROD a popular closed-board article's body teaser
-# IS reachable (verified by running that cron SQL against a qualifying
-# canary). This DB pin therefore guards the SEED's data shape only (the
-# canary stays out of the table for lack of engagement); the real fix --
-# an m_read filter in the cron and in news.cgi -- lands in the stacked
-# news-fix PR, where this pin becomes a live test. HTTP assertion here
-# would be structurally vacuous (5-day window vs fixed seed dates).
+# Front-page channels, tested LIVE end to end. The closed canary article
+# carries qualifying engagement (recom 5, count 50, created within the hot
+# window -- see seed.pl), so when we run the REAL stat populators below,
+# only their new m_read=1 filter keeps it out of the feeder tables; the
+# open control article (same engagement + CANARY_CONTROL body token) MUST
+# come through, proving the cron and the hot teaser are actually live --
+# no assertion here can pass vacuously.
+ctrlaid=$(db "SELECT article_id FROM bw_xboard_body WHERE body LIKE '%$CANARY_CONTROL%' LIMIT 1") || exit 1
+[ -n "$ctrlaid" ] && [ "$ctrlaid" != "NULL" ] || fail "hot-control article not seeded"
+# SQL passed as an argument, not stdin: `compose exec < file` hangs on some
+# compose versions (v2.0.0-beta.4 measured); the -e argv path is the same
+# shape db() uses and works everywhere. mariadb -e runs multi-statement.
+db "$(cat main/sql/update_article_stat.sql)" >/dev/null \
+    || fail "update_article_stat.sql failed against the seeded DB"
+db "$(cat main/sql/update_xboard_stat.sql)" >/dev/null \
+    || fail "update_xboard_stat.sql failed against the seeded DB"
+got=$(db "SELECT COUNT(*) FROM bw_xboard_stat_article WHERE article_id=$ctrlaid") || exit 1
+[ "$got" = "1" ] || fail "open control did not enter stat_article -- cron test is vacuous (got '$got')"
 got=$(db "SELECT COUNT(*) FROM bw_xboard_stat_article WHERE board_id=$cbid") || exit 1
-[ "$got" = "0" ] || fail "closed-board article entered bw_xboard_stat_article (front-page teaser feeder)"
-ok "closed board absent from the front-page teaser feeder (stat_article)"
+[ "$got" = "0" ] || fail "LEAK: engaged closed-board article entered stat_article through the cron"
+got=$(db "SELECT COUNT(*) FROM bw_xboard_stat_board WHERE board_id=$cbid") || exit 1
+[ "$got" = "0" ] || fail "LEAK: closed board entered stat_board through the cron"
+ok "stat crons admit the control and exclude the closed board (live)"
 
-# KNOWN LEAK, pinned deliberately: news.cgi's \$recent list (40 newest
-# titles) has NO membership filter, so the closed board's article TITLE is
-# on the front page for every logged-in member (empirically confirmed;
-# PR #32 discussion). The body token must still be absent (bodies are not
-# served there). The window pin below keeps the \$CANARY_TITLE assertion
-# honest: it fails as "stale stack" when the canary merely aged out of the
-# 40-newest list (each non-reseeded run posts one newer article), and only
-# blames news.cgi when the canary is provably still in the window. When
-# news.cgi gains a membership/closed-group filter, the \$CANARY_TITLE
-# assertion fails WITH the window pin green -- that is the signal to FLIP
-# it to `has ... && fail "LEAK"` like its siblings, KEEPING the window pin
-# as the flipped check's non-vacuity control. Until then CI documents the
-# truth instead of certifying a safety that does not exist.
+# window pin: keeps the title assertions below non-vacuous (the canary must
+# still be within news.cgi's 40-newest \$recent window to be assertable).
 newer=$(db "SELECT COUNT(*) FROM bw_xboard_header WHERE article_id > $caid") || exit 1
 [ "$newer" -lt 40 ] || fail "canary fell off the 40-newest list ($newer newer articles) -- stale stack: reseed and re-run"
 fetch "$J7" "$BASE/main/news.cgi"
 [ "$CODE" = "200" ] || fail "news.cgi: HTTP $CODE"
 has "자유게시판" || fail "news.cgi recent list not rendering seeded data (liveness)"
-has "$CANARY_TITLE" || fail "closed-board title off the front page while the canary IS in the recent window -- news.cgi gained a filter; FLIP this known-leak assertion, keep the window pin (see PR #32)"
-has "$CANARY_ARTICLE" && fail "LEAK: canary BODY served on the front page"
-ok "front page: bodies safe; title leak pinned as KNOWN (flip when news.cgi is fixed)"
+has "$CANARY_CONTROL" || fail "hot teaser not serving the open control body (channel vacuous)"
+has "$CANARY_TITLE" && fail "LEAK: closed-board title served on the front page"
+has "$CANARY_ARTICLE" && fail "LEAK: closed-board body served on the front page"
+ok "front page: hot teaser live; closed board fully absent (titles + bodies)"
 
 # private note: recipient inbox and sender sent-box see it; nobody else.
 login tester02; J2=$JAR


### PR DESCRIPTION
## The leak (confirmed live during PR #32's review)

`main/news.cgi` builds four member-global lists with **no membership filter**: `$recent` (40 newest titles + read links), `$hot` (title + 1000-char body teaser via `bw_xboard_stat_article`), the top-3 boards panel, and the new-boards panel. A closed-group board passes every filter they have — non-member tester07's front page contained the closed board's article title and a direct read link. Worse, the feeder crons admit rows on engagement alone: running `main/sql/update_article_stat.sql` against a closed-board article with recom 5 / count 50 put it straight into the body-teaser feeder. The hardcoded fossils (`gid!=18`, `board_id!=688`, `!=637`) show this leaked before and got patched one instance at a time.

## The fix — one condition, six places

`m_read=1`: boards readable by **every** logged-in member per `Bawi::Board::Group::authz` (news.cgi is auth-gated, so the viewer is always a member; `m_read=0` boards are group-gated and never belong on a global page).

| Site | Covers |
|---|---|
| `news.cgi` `$recent` | recent-titles list |
| `news.cgi` `$hot` | body-teaser serve side |
| `news.cgi` top-3 boards | board-titles panel |
| `news.cgi` new-boards | new-board titles + owner ids |
| `update_article_stat.sql` | the teaser **feeder** → also protects `hot.cgi` |
| `update_xboard_stat.sql` | board-stat feeder → also protects `stat.cgi` |

Producer + serve-side both filtered (defense in depth). User stats untouched (counts only, no titles). Legacy hardcoded exclusions kept.

**Tradeoff (deliberate):** the filter is viewer-independent — closed-group members also stop seeing their boards on the shared front page (per-viewer filtering = a query per row on an uncached page). They see everything on the boards themselves.

## Tests: from pinned-known-leak to live end-to-end (24/24)

Executes PR #32's flip instruction, window pin kept as the non-vacuity control. The seed now gives the closed canary **qualifying engagement** (recom 5, count 50, in-window date, distinct-ki recommenders) so *only* the m_read filter excludes it, plus an equally-engaged **open control article** with a body token that must come through. Tier 3 runs the **real cron SQLs** against the seeded DB and asserts: control admitted, closed board excluded from both stat tables; then the news.cgi fetch requires the control's teaser present (hot channel proven live) and both canary tokens absent. No assertion can pass vacuously.

(Cron SQL is fed via argv, not stdin — `compose exec < file` hangs on compose v2.0.0-beta.4, measured.)

## Deploy

`git pull` + `apachectl graceful`; the cron picks up the new SQL on its next run, flushing any closed-board rows already in the stat tables.

## Not in this PR

The anonymous board-NAME shell exposure (`AllowAnonAccess=1` serves closed-board names/owner-ids to logged-out visitors on `read.cgi` shells; `db-test.cgi` lists all board titles unauthenticated) — separate decision, debrief delivered, awaiting the owner's A / A+B / C call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc1nVmGtH3kCoPnPdzNY1e