### PR TITLE
fix(auth): close anonymous exposure of members-only boards (shell, thumbnails, diagnostics)

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -66,7 +66,7 @@ Useful URLs once logged in:
 - `http://localhost:8080/board/boards.cgi` — board list
 - `http://localhost:8080/main/news.cgi` — recent articles
 - `http://localhost:8080/main/note.cgi` — notes (41 seeded; each of the first 10 users has 1 unread, plus a second unread privacy-canary note for tester02 — see `t/smoke.sh`)
-- `http://localhost:8080/main/db-test.cgi` — plain-text DB connectivity check
+- `http://localhost:8080/main/db-test.cgi` — plain-text DB connectivity check (members-only since PR #34; log in first)
 
 ## Everyday commands
 
@@ -94,11 +94,10 @@ prod path hardcoded in `apache2/startup.pl`), so host edits are live.
 Through the real stack (recommended — exercises mod_perl exactly like prod):
 
 ```sh
-curl -s http://localhost:8080/main/db-test.cgi
-
-# authenticated: log in once, keep the session cookie
+# log in once, keep the session cookie (db-test.cgi is members-only, PR #34)
 curl -s -c /tmp/bawi.jar -d 'id=tester02&passwd=test1234' \
      http://localhost:8080/main/login.cgi -o /dev/null
+curl -s -b /tmp/bawi.jar http://localhost:8080/main/db-test.cgi
 curl -s -b /tmp/bawi.jar http://localhost:8080/board/index.cgi
 ```
 
@@ -111,6 +110,7 @@ cd /home/bawi/bawi-spring/main
 export BAWI_PERL_HOME=/home/bawi/bawi-spring/ BAWI_DATA_HOME=/home/bawi/bawi-data/
 perl -I/home/bawi/bawi-spring/lib -c db-test.cgi        # compile check
 REQUEST_METHOD=GET QUERY_STRING='' perl -I/home/bawi/bawi-spring/lib db-test.cgi
+# (prints the login redirect: db-test.cgi is members-only since PR #34)
 ```
 
 ## Migrations
@@ -153,14 +153,14 @@ retrying — a half-initialized data dir skips init on the next start.
 
 ## Validation checklist (what "working" looks like)
 
-The checklist is automated: `./seed/reseed.sh && sh t/smoke.sh` (currently 24
-checks -- the script asserts its own count, see `EXPECTED` -- including the
+The checklist is automated: `./seed/reseed.sh && sh t/smoke.sh` (the script
+asserts its own check count, see `EXPECTED` -- including the
 privacy-canary assertions the manual list below does not cover). The items
 below remain as the hand-debug annex.
 
 1. `docker compose ps` — the db and web containers both `Up`.
 2. `docker compose exec -T db mariadb -u bawi_test -pbawi-local-test-pw bawi -e "SHOW TABLES" | wc -l` → 64 lines: 1 column-header line + 62 tables (incl. `schema_migrations` and the `bw_migration_20260718_innodb_applied` replay sentinel) + the `freq_bookmark` view. (Grows by one per table a migration adds — cross-check against the runner's state listing in `docker compose logs db`.)
-3. `curl -s http://localhost:8080/main/db-test.cgi` → three `before query:/after query:/dbh->errstr:` lines then the seven seeded board titles — including the closed privacy-canary board `비공개 테스트판` (no 500; see `t/smoke.sh` tier 3).
+3. `curl -s http://localhost:8080/main/db-test.cgi` → 302 to the login page (members-only since PR #34). With the session jar from item 5: `curl -s -b /tmp/bawi.jar http://localhost:8080/main/db-test.cgi` → the three `before query:/after query:/dbh->errstr:` lines and a `boards: N` row count — the title dump is gone (it enumerated closed boards to any member; no 500; see `t/smoke.sh` tiers 1-2).
 4. `curl -s http://localhost:8080/` → login page HTML (200).
 5. Login POST (see above) → `302` with `Set-Cookie: bawi_session=…`.
 6. `curl -s -b /tmp/bawi.jar http://localhost:8080/board/index.cgi` → bookmark page listing seeded boards.

--- a/board/boardcfg.cgi
+++ b/board/boardcfg.cgi
@@ -36,6 +36,16 @@ unless ($xb and $xb->board_id) {
     print $ui->output; exit;
 }
 
+# Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
+# marked publicly readable may render ANYTHING: even the page SHELL leaks
+# the board name, its group's name, and the owner's name/id (verified --
+# PR #34). Members-only boards bounce anonymous visitors to login here,
+# before any board data is emitted. Anon boards keep guest access.
+unless ($auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
+    print $auth->login_page($ui->cgiurl);
+    exit (1);
+}
+
 my $uid = $auth->uid || 0;
 my $is_root = $uid == 1 ? 1 : 0;
 my $is_owner = ($uid == $xb->uid) || $is_root ? 1 : 0;

--- a/board/boardcfg.cgi
+++ b/board/boardcfg.cgi
@@ -36,16 +36,6 @@ unless ($xb and $xb->board_id) {
     print $ui->output; exit;
 }
 
-# Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
-# marked publicly readable may render ANYTHING: even the page SHELL leaks
-# the board name, its group's name, and the owner's name/id (verified --
-# PR #34). Members-only boards bounce anonymous visitors to login here,
-# before any board data is emitted. Anon boards keep guest access.
-unless ($auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
-    print $auth->login_page($ui->cgiurl);
-    exit (1);
-}
-
 my $uid = $auth->uid || 0;
 my $is_root = $uid == 1 ? 1 : 0;
 my $is_owner = ($uid == $xb->uid) || $is_root ? 1 : 0;

--- a/board/comment.cgi
+++ b/board/comment.cgi
@@ -21,13 +21,26 @@ my ($action, $bid, $aid, $p, $img) = map {$q->param($_) || ''} qw(action bid aid
 my $xb = new Bawi::Board(-board_id=>$bid, -cfg=>$ui->cfg, -dbh=>$ui->dbh)
     if ($bid);
 
-# Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
-# marked publicly readable may render ANYTHING: even the page SHELL leaks
-# the board name, its group's name, and the owner's name/id (verified --
-# PR #34). Members-only boards bounce anonymous visitors to login here,
-# before any board data is emitted. Anon boards keep guest access.
-unless (!$xb || $auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
-    print $auth->login_page($ui->cgiurl);
+# Action endpoint: no page shell renders here (every exit is a redirect
+# or XML), but bounce anonymous requests against members-only boards
+# before any processing, in parity with read.cgi's shell guard (PR #34).
+# Guests proceed when the board grants anonymous read or anonymous
+# comment (authz(-aperm=>a_comment) below still gates the actual action).
+# is_anonboard masks author identity, it never grants access. !$xb: a
+# bid-less request has no board to leak; it falls through to the
+# pre-existing error path at the Group constructor below.
+unless (!$xb || $auth->auth || ($xb->a_read || 0) == 1 || ($xb->a_comment || 0) == 1) {
+    # A POST's return URL must not carry the request params: cgiurl
+    # rebuilds the query from them, comment body included -- member text
+    # in the Location header and access logs, and a long body 414s the
+    # login redirect (the post-login GET replay could not re-add the
+    # comment anyway). Point a bounced POST back at the article.
+    my $back = $ui->cgiurl;
+    if (($q->request_method || '') eq 'POST') {
+        ($back = $q->url(-path_info=>1)) =~ s{comment\.cgi\z}{read.cgi};
+        $back .= '?bid=' . $q->escape($bid) . ';aid=' . $q->escape($aid);
+    }
+    print $auth->login_page($back);
     exit (1);
 }
 

--- a/board/comment.cgi
+++ b/board/comment.cgi
@@ -21,6 +21,16 @@ my ($action, $bid, $aid, $p, $img) = map {$q->param($_) || ''} qw(action bid aid
 my $xb = new Bawi::Board(-board_id=>$bid, -cfg=>$ui->cfg, -dbh=>$ui->dbh)
     if ($bid);
 
+# Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
+# marked publicly readable may render ANYTHING: even the page SHELL leaks
+# the board name, its group's name, and the owner's name/id (verified --
+# PR #34). Members-only boards bounce anonymous visitors to login here,
+# before any board data is emitted. Anon boards keep guest access.
+unless (!$xb || $auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
+    print $auth->login_page($ui->cgiurl);
+    exit (1);
+}
+
 my $grp = new Bawi::Board::Group(-gid=>$xb->gid, -cfg=>$ui->cfg, -dbh=>$ui->dbh);
 my ($uid, $id, $name);
 if ($auth->auth) {

--- a/board/commentx.cgi
+++ b/board/commentx.cgi
@@ -21,6 +21,16 @@ my ($action, $bid, $aid, $p, $img) = map {$q->param($_) || ''} qw(action bid aid
 my $xb = new Bawi::Board(-board_id=>$bid, -cfg=>$ui->cfg, -dbh=>$ui->dbh) 
     if ($bid);
 
+# Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
+# marked publicly readable may render ANYTHING: even the page SHELL leaks
+# the board name, its group's name, and the owner's name/id (verified --
+# PR #34). Members-only boards bounce anonymous visitors to login here,
+# before any board data is emitted. Anon boards keep guest access.
+unless (!$xb || $auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
+    print $auth->login_page($ui->cgiurl);
+    exit (1);
+}
+
 my $grp = new Bawi::Board::Group(-gid=>$xb->gid, -cfg=>$ui->cfg, -dbh=>$ui->dbh);
 my ($uid, $id, $name);
 if ($auth->auth) {

--- a/board/commentx.cgi
+++ b/board/commentx.cgi
@@ -21,13 +21,26 @@ my ($action, $bid, $aid, $p, $img) = map {$q->param($_) || ''} qw(action bid aid
 my $xb = new Bawi::Board(-board_id=>$bid, -cfg=>$ui->cfg, -dbh=>$ui->dbh) 
     if ($bid);
 
-# Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
-# marked publicly readable may render ANYTHING: even the page SHELL leaks
-# the board name, its group's name, and the owner's name/id (verified --
-# PR #34). Members-only boards bounce anonymous visitors to login here,
-# before any board data is emitted. Anon boards keep guest access.
-unless (!$xb || $auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
-    print $auth->login_page($ui->cgiurl);
+# Action endpoint: no page shell renders here (every exit is a redirect
+# or XML), but bounce anonymous requests against members-only boards
+# before any processing, in parity with read.cgi's shell guard (PR #34).
+# Guests proceed when the board grants anonymous read or anonymous
+# comment (authz(-aperm=>a_comment) below still gates the actual action).
+# is_anonboard masks author identity, it never grants access. !$xb: a
+# bid-less request has no board to leak; it falls through to the
+# pre-existing error path at the Group constructor below.
+unless (!$xb || $auth->auth || ($xb->a_read || 0) == 1 || ($xb->a_comment || 0) == 1) {
+    # A POST's return URL must not carry the request params: cgiurl
+    # rebuilds the query from them, comment body included -- member text
+    # in the Location header and access logs, and a long body 414s the
+    # login redirect (the post-login GET replay could not re-add the
+    # comment anyway). Point a bounced POST back at the article.
+    my $back = $ui->cgiurl;
+    if (($q->request_method || '') eq 'POST') {
+        ($back = $q->url(-path_info=>1)) =~ s{commentx\.cgi\z}{read.cgi};
+        $back .= '?bid=' . $q->escape($bid) . ';aid=' . $q->escape($aid);
+    }
+    print $auth->login_page($back);
     exit (1);
 }
 

--- a/board/read.cgi
+++ b/board/read.cgi
@@ -50,11 +50,12 @@ my $xb = new Bawi::Board(-board_id     => $bid,
                           -session_key  => $session_key);
 
 # Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
-# marked publicly readable may render ANYTHING: even the page SHELL leaks
-# the board name, its group's name, and the owner's name/id (verified --
-# PR #34). Members-only boards bounce anonymous visitors to login here,
-# before any board data is emitted. Anon boards keep guest access.
-unless ($auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
+# whose OWN config grants guests the read action may render anything: even
+# the page SHELL leaks the board name, its group's name, and the owner's
+# name/id (verified -- PR #34). The predicate mirrors Group::authz, where
+# a guest (uid 0) is granted read solely by a_read==1. is_anonboard is an
+# identity-masking flag, never an access grant, so it plays no part here.
+unless ($auth->auth || ($xb->a_read || 0) == 1) {
     print $auth->login_page($ui->cgiurl);
     exit (1);
 }

--- a/board/read.cgi
+++ b/board/read.cgi
@@ -49,6 +49,16 @@ my $xb = new Bawi::Board(-board_id     => $bid,
                           -dbh          => $ui->dbh,
                           -session_key  => $session_key);
 
+# Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
+# marked publicly readable may render ANYTHING: even the page SHELL leaks
+# the board name, its group's name, and the owner's name/id (verified --
+# PR #34). Members-only boards bounce anonymous visitors to login here,
+# before any board data is emitted. Anon boards keep guest access.
+unless ($auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
+    print $auth->login_page($ui->cgiurl);
+    exit (1);
+}
+
 my $skin = $xb->skin || 'default';
 $ui->init(-template=>'read.tmpl', -skin=>$skin);
 $ui->term(qw(T_BOOKMARK T_PREV T_NEXT T_NEWARTICLES T_IMGLIST T_ARTICLELIST T_WRITE T_THREAD T_REPLY T_EDIT T_DELETE T_TITLE T_NAME T_ID T_ADDBOOKMARK T_DELBOOKMARK T_SCRAP T_SCRAPPED T_READ T_RECOMMEND T_RECOMMENDED T_RETRACT T_RETRACTED T_BOARDCFG T_ADDNOTICE T_DELETENOTICE T_NEWCOMMENTS T_COMMENT T_SAVE T_RESET));

--- a/board/t.cgi
+++ b/board/t.cgi
@@ -6,6 +6,18 @@ use CGI;
 
 use lib '../lib';
 use Bawi::Board::Config;
+use Bawi::Board::UI;
+use Bawi::Auth;
+
+# %ENV dump (server paths, mod_perl internals): members only -- this
+# diagnostic was reachable unauthenticated, same class as main/db-test.cgi
+# (PR #34).
+my $ui = new Bawi::Board::UI;
+my $auth = new Bawi::Auth(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
+unless ($auth->auth) {
+    print $auth->login_page($ui->cgiurl);
+    exit (1);
+}
 
 my $q = new CGI;
 print $q->header;

--- a/board/thumb.cgi
+++ b/board/thumb.cgi
@@ -3,13 +3,31 @@ use strict;
 use lib '../lib';
 use Bawi::Board::UI;
 use Bawi::Board;
+use Bawi::Auth;
 
 my $ui = new Bawi::Board::UI;
+my $auth = new Bawi::Auth(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
 
 my $atid = $ui->cparam('atid');
 
 my $xb = new Bawi::Board(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
 my $attach = $xb->get_attach(-attach_id=>$atid, -thumb=>1);
+
+# Thumbnails are board content: full files go through attach.cgi's auth
+# gate, but this CGI served any atid to anyone (PR #34). Guests may fetch
+# a thumbnail only off boards that grant anonymous read (a_read=1, the
+# same predicate as read.cgi's shell guard); members keep today's
+# behavior. A row whose board is gone fails closed for guests; a no-row
+# atid skips the gate -- there is nothing to leak -- and keeps the
+# pre-existing not-found path.
+if ($attach) {
+    my $bxb = new Bawi::Board(-cfg=>$ui->cfg, -dbh=>$ui->dbh,
+                              -board_id=>$$attach{board_id});
+    unless ($auth->auth || ($bxb->a_read || 0) == 1) {
+        print $auth->login_page($ui->cgiurl);
+        exit (1);
+    }
+}
 
 if ($attach and $$attach{filehandle}) {
     # This is the thumbnail URL the templates actually emit, so it takes

--- a/board/write.cgi
+++ b/board/write.cgi
@@ -25,12 +25,22 @@ my ($bid, $aid, $resize, $img) = map { $q->param($_) || undef } qw( bid aid resi
 my $xb = new Bawi::Board(-board_id=>$bid, -cfg=>$ui->cfg, -dbh=>$ui->dbh);
 
 # Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
-# marked publicly readable may render ANYTHING: even the page SHELL leaks
-# the board name, its group's name, and the owner's name/id (verified --
-# PR #34). Members-only boards bounce anonymous visitors to login here,
-# before any board data is emitted. Anon boards keep guest access.
-unless ($auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
-    print $auth->login_page($ui->cgiurl);
+# whose OWN config grants guests an action here may render anything: even
+# the page SHELL leaks the board name, its group's name, and the owner's
+# name/id (verified -- PR #34). Guests get the write form when the board
+# grants anonymous read OR anonymous write (an a_write=1 guest drop-box
+# must ship its form; authz(-aperm=>a_write) below still gates the actual
+# post). is_anonboard masks author identity, it never grants access.
+unless ($auth->auth || ($xb->a_read || 0) == 1 || ($xb->a_write || 0) == 1) {
+    # Same POST rule as comment.cgi: never round-trip a POST body through
+    # the return URL (Location/access logs, 414 past ~8KB, and a GET
+    # replay would mint a history-replayable create URL). Send a bounced
+    # POST back to the blank write form for this board.
+    my $back = $ui->cgiurl;
+    if (($q->request_method || '') eq 'POST') {
+        $back = $q->url(-path_info=>1) . '?bid=' . $q->escape($bid || '');
+    }
+    print $auth->login_page($back);
     exit (1);
 }
 my $skin = $xb->skin;

--- a/board/write.cgi
+++ b/board/write.cgi
@@ -23,6 +23,16 @@ my $q = $ui->cgi;
 my ($bid, $aid, $resize, $img) = map { $q->param($_) || undef } qw( bid aid resize img);
 
 my $xb = new Bawi::Board(-board_id=>$bid, -cfg=>$ui->cfg, -dbh=>$ui->dbh);
+
+# Anonymous visitors reach this CGI when AllowAnonAccess=1, but only boards
+# marked publicly readable may render ANYTHING: even the page SHELL leaks
+# the board name, its group's name, and the owner's name/id (verified --
+# PR #34). Members-only boards bounce anonymous visitors to login here,
+# before any board data is emitted. Anon boards keep guest access.
+unless ($auth->auth || ($xb->a_read || 0) == 1 || $xb->is_anonboard) {
+    print $auth->login_page($ui->cgiurl);
+    exit (1);
+}
 my $skin = $xb->skin;
 
 my ($uid, $id, $name);

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -2127,6 +2127,7 @@ sub get_attach {
             seek(FH, 0, 0);
             my %attach = (
                 article_id=> $$rv{article_id},
+                board_id=> $$rv{board_id}, # thumb.cgi gates on the board's anon-read flag
                 filename=> $$rv{filename},
                 filesize=> $filesize,
                 content_type=> $$rv{content_type},

--- a/main/db-test.cgi
+++ b/main/db-test.cgi
@@ -3,16 +3,17 @@ use strict;
 use warnings;
 use lib '../lib';
 use Bawi::Main::UI;
+use Bawi::Auth;
 
 #$ENV{BAWI_PERL_HOME} = "/home/bawi/bawi-perl/";
 #$ENV{BAWI_DATA_HOME} = "/home/bawi/bawi-data/";
 
 my $ui = new Bawi::Main::UI(-template=>'index.tmpl');
 
-# Diagnostic page: enumerates every board title. Members only -- this was
-# reachable unauthenticated on prod, handing anonymous visitors a complete
-# board directory (closed boards included). PR #34.
-use Bawi::Auth;
+# DB diagnostic page, members only (PR #34): it was reachable
+# unauthenticated on prod. It also used to print every board title
+# (board_id < 100), which after 3839308's front-page fix would hand any
+# member the closed-board directory -- so it now reports only a row count.
 my $auth = new Bawi::Auth(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
 unless ($auth->auth) {
     print $auth->login_page($ui->cgiurl);
@@ -27,7 +28,7 @@ print "after query: ",$dbh->state,"\n";
 print "dbh->errstr: ",$dbh->errstr,"\n";
 $sth->execute(100);
 
-while( my @tmp = $sth->fetchrow_array() ) {
-    print $tmp[0],"\n";
-}
+my $n = 0;
+$n++ while $sth->fetchrow_array();
+print "boards: $n\n";
 $dbh->disconnect();

--- a/main/db-test.cgi
+++ b/main/db-test.cgi
@@ -9,6 +9,16 @@ use Bawi::Main::UI;
 
 my $ui = new Bawi::Main::UI(-template=>'index.tmpl');
 
+# Diagnostic page: enumerates every board title. Members only -- this was
+# reachable unauthenticated on prod, handing anonymous visitors a complete
+# board directory (closed boards included). PR #34.
+use Bawi::Auth;
+my $auth = new Bawi::Auth(-cfg=>$ui->cfg, -dbh=>$ui->dbh);
+unless ($auth->auth) {
+    print $auth->login_page($ui->cgiurl);
+    exit (1);
+}
+
 print $ui->cgi->header(-type=>'text/plain');
 my $dbh = $ui->dbh;
 print "before query: ",$dbh->state,"\n";

--- a/seed/seed.pl
+++ b/seed/seed.pl
@@ -462,6 +462,43 @@ use constant CANARY_CONTROL => 'CONTROL-HOT-a9d2c4';
         dt(BASE_EPOCH + 86400 * 401));
 }
 
+# ------------------------------------------------- PR #34 guard fixtures
+# Pin the per-action anonymous predicate from both sides, plus one
+# attachment ROW (no file on disk needed: thumb.cgi's gate keys on the
+# row's board and fires before any bytes are read).
+#   - members-only anonboard (is_anonboard=1, a_read=0): is_anonboard
+#     masks author identity and grants NO access -- anon must bounce.
+#   - guest drop-box (a_write=1, a_read=0): the write form must still
+#     serve guests (the over-block direction).
+# Ids derived from the DB; no articles added, so the canary "40 highest
+# article_ids" invariant above is untouched.
+print "seeding PR #34 guard fixtures (anonboard, drop-box, canary attach row)\n";
+{
+    my ($maxb) = $dbh->selectrow_array(q(SELECT MAX(board_id) FROM bw_xboard_board));
+    my $b = $dbh->prepare(q(
+        INSERT INTO bw_xboard_board
+            (board_id, keyword, gid, title, uid, id, name, skin, seq, created,
+             g_read, m_read, a_read, g_write, m_write, a_write,
+             g_comment, m_comment, a_comment, is_anonboard)
+        VALUES (?,?,?,?,1,'root',?,'default',?,?, ?,?,?, ?,?,?, ?,?,?, ?)));
+    $b->execute($maxb + 1, 'anonymous', 2, '익명 비공개판 테스트', $uname{1},
+                $maxb + 1, dt(BASE_EPOCH + 86400 * 8),
+                1,1,0, 1,1,0, 1,1,0, 1);
+    $b->execute($maxb + 2, 'dropbox', 1, '건의함 테스트', $uname{1},
+                $maxb + 2, dt(BASE_EPOCH + 86400 * 9),
+                1,1,0, 1,1,1, 1,1,0, 0);
+
+    my ($cb2) = $dbh->selectrow_array(
+        q(SELECT board_id FROM bw_xboard_board WHERE title='비공개 테스트판'));
+    my ($ca2) = $dbh->selectrow_array(
+        q(SELECT MIN(article_id) FROM bw_xboard_header WHERE board_id=?), undef, $cb2);
+    $dbh->do(q(
+        INSERT INTO bw_xboard_attach
+            (board_id, article_id, filename, filesize, content_type, is_img)
+        VALUES (?,?,?,123,'image/jpeg','y')),
+        undef, $cb2, $ca2, 'canary-attach.jpg');
+}
+
 # ------------------------------------------------------------ article polls
 print "seeding 2 article polls\n";
 {

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -36,7 +36,7 @@
 set -u
 cd "$(dirname "$0")/.."
 
-EXPECTED=24
+EXPECTED=26
 PASS='test1234'
 CANARY_ARTICLE='CANARY-ARTICLE-b7a2f9'
 CANARY_TITLE='CANARY-TITLE-c7d4e2'
@@ -161,10 +161,10 @@ for f in db/2*.sql; do
 done
 ok "all $(ls db/2*.sql | wc -l | tr -d ' ') migrations recorded in schema_migrations"
 
+# db-test.cgi enumerates every board title -> members only (PR #34).
 fetch - "$BASE/main/db-test.cgi"
-[ "$CODE" = "200" ] || fail "db-test.cgi: HTTP $CODE"
-has "before query" || fail "db-test.cgi: missing marker output"
-ok "db-test.cgi serves and reaches the DB"
+[ "$CODE" = "302" ] || fail "unauthenticated db-test.cgi: expected 302, got $CODE"
+ok "db-test.cgi requires login"
 
 # ======================================================== tier 2: golden path
 fetch - "$BASE/"
@@ -177,6 +177,11 @@ ok "login tester02 -> 302 + session cookie"
 fetch "$J2" "$BASE/board/index.cgi"
 [ "$CODE" = "200" ] || fail "board index: HTTP $CODE"
 ok "board index serves for a member"
+
+fetch "$J2" "$BASE/main/db-test.cgi"
+[ "$CODE" = "200" ] || fail "authed db-test.cgi: HTTP $CODE"
+has "before query" || fail "db-test.cgi: missing marker output"
+ok "db-test.cgi serves its diagnostics to a member"
 
 aid=$(db "SELECT MIN(article_id) FROM bw_xboard_header WHERE board_id=2") || exit 1
 [ -n "$aid" ] && [ "$aid" != "NULL" ] || fail "no seeded article on board 2 (got '$aid')"
@@ -245,17 +250,26 @@ has "$CANARY_ARTICLE" || fail "member tester03 cannot read the canary body (test
 has "$CANARY_TITLE"   || fail "member tester03 does not see the canary title (test would be vacuous)"
 ok "canary readable by a non-owner group member (positive control)"
 
-# logged-out: never a token. With AllowAnonAccess=1 (this stack AND the
-# conf samples) board CGIs serve anonymous visitors a 200 page SHELL and let
-# authz suppress the article; with AllowAnonAccess=0 they 302 to login.
-# Either status is policy -- the privacy property is the absent tokens.
-# (Note: the shell does expose the closed BOARD's name to anonymous
-# visitors -- board existence, not content; see PR #32 discussion.)
+# logged-out: members-only boards now bounce anonymous visitors BEFORE any
+# board data is emitted (PR #34) -- even the shell used to leak the board
+# name, group name, and owner id. Assert the redirect AND the absence of
+# every one of those strings, then prove the guard did not over-block:
+# the a_read=1 notice board must still serve guests (the feature
+# AllowAnonAccess exists for).
 fetch - "$BASE/board/read.cgi?bid=$cbid&aid=$caid"
-[ "$CODE" = "200" ] || [ "$CODE" = "302" ] || fail "logged-out canary read: HTTP $CODE"
+[ "$CODE" = "302" ] || fail "logged-out closed-board read: expected 302, got $CODE"
 has "$CANARY_ARTICLE" && fail "LEAK: canary body served logged-out"
 has "$CANARY_TITLE"   && fail "LEAK: canary title served logged-out"
-ok "canary not served logged-out"
+has "비공개 테스트판"  && fail "LEAK: closed board NAME in the anonymous response"
+has "비공개 테스트"    && fail "LEAK: closed GROUP name in the anonymous response"
+ok "closed-board shell not served logged-out (name/group/owner hidden)"
+
+naid=$(db "SELECT MIN(article_id) FROM bw_xboard_header WHERE board_id=1") || exit 1
+[ -n "$naid" ] && [ "$naid" != "NULL" ] || fail "no seeded article on the notice board"
+fetch - "$BASE/board/read.cgi?bid=1&aid=$naid"
+[ "$CODE" = "200" ] || fail "guest read of the a_read=1 notice board: HTTP $CODE (guard over-blocked)"
+has "공지사항" || fail "notice board not rendering for a guest"
+ok "public notice board still serves guests (guard does not over-block)"
 
 # wrong member (tester07 is not in gid 3): never. This is THE member-to-member
 # leak assertion.

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -36,7 +36,7 @@
 set -u
 cd "$(dirname "$0")/.."
 
-EXPECTED=26
+EXPECTED=32
 PASS='test1234'
 CANARY_ARTICLE='CANARY-ARTICLE-b7a2f9'
 CANARY_TITLE='CANARY-TITLE-c7d4e2'
@@ -161,7 +161,8 @@ for f in db/2*.sql; do
 done
 ok "all $(ls db/2*.sql | wc -l | tr -d ' ') migrations recorded in schema_migrations"
 
-# db-test.cgi enumerates every board title -> members only (PR #34).
+# db-test.cgi DB diagnostic -> members only (PR #34); its board-title
+# dump is gone too (it enumerated closed boards to any member).
 fetch - "$BASE/main/db-test.cgi"
 [ "$CODE" = "302" ] || fail "unauthenticated db-test.cgi: expected 302, got $CODE"
 ok "db-test.cgi requires login"
@@ -250,18 +251,24 @@ has "$CANARY_ARTICLE" || fail "member tester03 cannot read the canary body (test
 has "$CANARY_TITLE"   || fail "member tester03 does not see the canary title (test would be vacuous)"
 ok "canary readable by a non-owner group member (positive control)"
 
-# logged-out: members-only boards now bounce anonymous visitors BEFORE any
-# board data is emitted (PR #34) -- even the shell used to leak the board
-# name, group name, and owner id. Assert the redirect AND the absence of
-# every one of those strings, then prove the guard did not over-block:
-# the a_read=1 notice board must still serve guests (the feature
-# AllowAnonAccess exists for).
+# logged-out: boards that grant guests no action bounce anonymous visitors
+# BEFORE any board data is emitted (PR #34) -- even the shell used to leak
+# the board name, group name, and owner name/id. The guard is per-action
+# (read: a_read; write: +a_write; comment: +a_comment; is_anonboard grants
+# nothing -- it only masks author identity). Assert the redirect AND the
+# absence of every leaked string, in every guarded CGI, from both
+# directions: closed surfaces bounce, the a_read=1 notice board and the
+# a_write=1 drop-box still serve guests.
+# NB: the group name is a prefix of the board name -- keep the board-name
+# check first so a board-name leak is attributed correctly.
 fetch - "$BASE/board/read.cgi?bid=$cbid&aid=$caid"
 [ "$CODE" = "302" ] || fail "logged-out closed-board read: expected 302, got $CODE"
 has "$CANARY_ARTICLE" && fail "LEAK: canary body served logged-out"
 has "$CANARY_TITLE"   && fail "LEAK: canary title served logged-out"
 has "비공개 테스트판"  && fail "LEAK: closed board NAME in the anonymous response"
 has "비공개 테스트"    && fail "LEAK: closed GROUP name in the anonymous response"
+has "tester02"        && fail "LEAK: closed board OWNER id in the anonymous response"
+has "테스트유저02"     && fail "LEAK: closed board OWNER name in the anonymous response"
 ok "closed-board shell not served logged-out (name/group/owner hidden)"
 
 naid=$(db "SELECT MIN(article_id) FROM bw_xboard_header WHERE board_id=1") || exit 1
@@ -270,6 +277,50 @@ fetch - "$BASE/board/read.cgi?bid=1&aid=$naid"
 [ "$CODE" = "200" ] || fail "guest read of the a_read=1 notice board: HTTP $CODE (guard over-blocked)"
 has "공지사항" || fail "notice board not rendering for a guest"
 ok "public notice board still serves guests (guard does not over-block)"
+
+# each action CGI carries its own copy of the guard -- pin every copy
+# against the closed board.
+fetch - "$BASE/board/write.cgi?bid=$cbid"
+[ "$CODE" = "302" ] || fail "logged-out closed-board write form: expected 302, got $CODE"
+has "비공개 테스트판" && fail "LEAK: closed board NAME on anonymous write.cgi"
+ok "write.cgi bounces logged-out visitors off the closed board"
+
+fetch - "$BASE/board/comment.cgi?bid=$cbid&aid=$caid"
+[ "$CODE" = "302" ] || fail "logged-out closed-board comment.cgi: expected 302, got $CODE"
+ok "comment.cgi bounces logged-out visitors off the closed board"
+
+fetch - "$BASE/board/commentx.cgi?bid=$cbid&aid=$caid"
+[ "$CODE" = "302" ] || fail "logged-out closed-board commentx.cgi: expected 302, got $CODE"
+ok "commentx.cgi bounces logged-out visitors off the closed board"
+
+# members-only anonboard: is_anonboard masks author identity, it must NOT
+# admit guests (the PR #34 review regression: an earlier guard draft
+# exempted it).
+anbid=$(db "SELECT board_id FROM bw_xboard_board WHERE is_anonboard=1 AND a_read=0 LIMIT 1") || exit 1
+[ -n "$anbid" ] && [ "$anbid" != "NULL" ] || fail "no seeded members-only anonboard"
+fetch - "$BASE/board/read.cgi?bid=$anbid"
+[ "$CODE" = "302" ] || fail "logged-out members-only anonboard read: expected 302, got $CODE"
+has "익명 비공개판" && fail "LEAK: members-only anonboard NAME in the anonymous response"
+ok "members-only anonboard shell not served logged-out"
+
+# guest drop-box (a_write=1, a_read=0): the write form must still serve
+# guests -- the over-block direction of the per-action predicate.
+dbbid=$(db "SELECT board_id FROM bw_xboard_board WHERE a_write=1 AND a_read=0 LIMIT 1") || exit 1
+[ -n "$dbbid" ] && [ "$dbbid" != "NULL" ] || fail "no seeded guest drop-box board"
+fetch - "$BASE/board/write.cgi?bid=$dbbid"
+[ "$CODE" = "200" ] || fail "guest write form on the a_write=1 drop-box: HTTP $CODE (guard over-blocked)"
+has "건의함" || fail "drop-box write form not rendering for a guest"
+ok "guest drop-box still serves its write form logged-out"
+
+# thumbnails are board content: an anonymous atid probe of a closed-board
+# attachment must bounce (PR #34; full files were already gated by
+# attach.cgi). The seeded row has no file on disk -- the gate fires on the
+# row's board before the bytes matter.
+catid=$(db "SELECT MIN(attach_id) FROM bw_xboard_attach WHERE board_id=$cbid") || exit 1
+[ -n "$catid" ] && [ "$catid" != "NULL" ] || fail "no seeded attachment row on the canary board"
+fetch - "$BASE/board/thumb.cgi?atid=$catid"
+[ "$CODE" = "302" ] || fail "logged-out closed-board thumbnail: expected 302, got $CODE"
+ok "thumb.cgi bounces logged-out visitors off closed-board attachments"
 
 # wrong member (tester07 is not in gid 3): never. This is THE member-to-member
 # leak assertion.


### PR DESCRIPTION
## The exposures (all verified)

1. **`main/db-test.cgi`** — an unauthenticated diagnostic page that listed **every board title** (closed boards included), reachable on prod. It also handed the same directory to **any logged-in member** — the leak class 3839308 fixed on the front page.
2. **Board-shell leak** — the four `AllowAnonAccess`-honoring CGIs (`read`, `write`, `comment`, `commentx`) serve anonymous visitors a page shell even for members-only boards. Authz suppresses the article, but the shell contains the **board name, its group's name, and the owner's display name + login id** — and board ids are small integers, so a crawler can enumerate the complete private-board directory in seconds. (`boardcfg.cgi` was originally listed too; review showed its line-14 gate already bounces every anonymous visitor — it was never exposed.)
3. **`board/thumb.cgi`** (found in review) — served **any attachment thumbnail by `atid` with no auth and no board authz**, including closed-board images: content bytes, a strictly worse leak than the shell metadata. Its full-file sibling `attach.cgi` was gated.
4. **`board/t.cgi`** (found in review) — dumped the entire `%ENV` (server paths, mod_perl internals) to anonymous visitors.

## The fix

- **A**: `db-test.cgi` requires login, and its board-title dump is replaced by a row count (members keep the DB state diagnostics).
- **B**: each action CGI bounces anonymous visitors to login **before emitting anything**, with a **per-action predicate mirroring `Group::authz` for uid 0**:
  - `read.cgi`: `a_read==1`
  - `write.cgi`: `a_read==1 || a_write==1` (an `a_write=1` guest drop-box must still ship its form; `authz(-aperm=>a_write)` still gates the actual post)
  - `comment.cgi` / `commentx.cgi`: `a_read==1 || a_comment==1`
  - `is_anonboard` grants **nothing** — it masks author identity. (An earlier draft exempted it, which would have kept leaking the shell of members-only anonboards — caught by Codex + the deep-review fleet.)
  - A bounced **POST** gets a body-less return URL: `cgiurl` rebuilds the query from POST params, so member text would land in the Location header and access logs, >8KB bodies would 414, and the post-login GET replay silently dropped the comment.
- **C**: `thumb.cgi` gates on auth or the attachment board's `a_read` (`get_attach` now returns `board_id`); `t.cgi` is members-only.

## Test coverage (t/smoke.sh, EXPECTED 26 → 32)

- Every guarded CGI pinned logged-out against the closed canary board (302 + no name/group/**owner id/name** strings).
- New seed fixtures span both predicate directions: a **members-only anonboard** (must bounce — the review regression) and a **guest drop-box** `a_write=1, a_read=0` (must still serve its form).
- Anonymous `thumb.cgi` probe of a closed-board attachment row → 302.
- `INSTALLATION.md` synced to the new db-test contract; stale check count dropped.

Review trail: 8-agent deep review + 2 Codex CLI reviews; all confirmed findings addressed in d8c5e42. All 32 smoke checks green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jDScffamzSfKnvZbqvpUi
