### PR TITLE
docs: record the real deploy model; retire stale sync-branch artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,11 @@ Each major section (board, user, admin) has its own set of CGI scripts and corre
 The canonical branch is **`main`**. The production deploy tree at
 `/home/bawi/bawi-spring` (host `orange`) is a direct checkout of `main` tracking
 `origin/main` (cutover from the former `resp2` line completed; verified live
-2026-08-28). Deploying merged work is: `git pull` + `apache2ctl graceful`
-(mod_perl caches `lib/*.pm` per worker), plus any new `db/` migrations applied
-in filename order BEFORE the pull when a PR adds them. Always confirm with
+2026-08-28). Deploying merged work is: `git pull`, then restart Apache as
+root — `sudo` is refused on this host, so `su -` into root and run
+`apache2ctl graceful` (mod_perl caches `lib/*.pm` per worker) — plus any new
+`db/` migrations applied in filename order BEFORE the pull when a PR adds
+them. Always confirm with
 `git -C /home/bawi/bawi-spring branch --show-current` and `git status` rather
 than trusting this note — stale branch-state notes have already misled one
 deploy plan (a session assumed `resp2` from the 2026-07-06 snapshot message).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,11 +95,19 @@ Each major section (board, user, admin) has its own set of CGI scripts and corre
 
 ## Git Branch Information
 
-The canonical branch is **`main`** (promoted from the former `resp2` line, which was the
-deployed branch). As captured from the production host on 2026-07-06, the deploy tree at
-`/home/bawi/bawi-spring` was checked out on `resp2`; the maintenance cutover repoints it at
-`main`. Always confirm with `git -C /home/bawi/bawi-spring branch --show-current` rather than
-trusting this note.
+The canonical branch is **`main`**. The production deploy tree at
+`/home/bawi/bawi-spring` (host `orange`) is a direct checkout of `main` tracking
+`origin/main` (cutover from the former `resp2` line completed; verified live
+2026-08-28). Deploying merged work is: `git pull` + `apache2ctl graceful`
+(mod_perl caches `lib/*.pm` per worker), plus any new `db/` migrations applied
+in filename order BEFORE the pull when a PR adds them. Always confirm with
+`git -C /home/bawi/bawi-spring branch --show-current` and `git status` rather
+than trusting this note — stale branch-state notes have already misled one
+deploy plan (a session assumed `resp2` from the 2026-07-06 snapshot message).
+Historical branches `resp2` and `resp2-live-snapshot` are archives of the
+pre-cutover line and its working-tree drift; `promote/live-state` (a fully
+merged live-mirror experiment) was deleted 2026-08-28 — do not recreate a
+mirror branch, read the box.
 
 **Git identity on the host**: user "bawi service account", email `bawi@orange.bawi.org`.
 
@@ -112,6 +120,11 @@ git -C /home/bawi/bawi-spring status
 ```
 The 2026-07 snapshot of that drift was preserved on branch `resp2-live-snapshot`. Credential
 files (`conf/*.tmp`) are gitignored and stay on the host only — never commit them.
+
+## Known Local Deviations
+
+- `lib/Bawi/Board.pm` mkdir (~line 1617): production keeps the historical 0777
+  permission; not changed in git.
 
 ## Code Management Guidelines
 

--- a/CLAUDE_MD_REVIEW.md
+++ b/CLAUDE_MD_REVIEW.md
@@ -1,0 +1,23 @@
+# CLAUDE.md context-engineering review (local note)
+
+_Local, uncommitted note — not pushed, no GitHub issue filed (production/shared repo). Reviewed 2026-07-26 against Anthropic's [New rules of context engineering for Claude 5](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models). Content is good; this is about **shape**._
+
+## This file is half exemplary, half the anti-pattern.
+
+### The good half (keep — it's textbook Claude-5 style)
+
+The live-state-over-stale-list gotchas are better than most examples in the article itself:
+- migrations: *"don't hardcode a list here, it goes stale… `for f in db/2*.sql`"*
+- branch: *"Always confirm with `git … branch --show-current` rather than trusting this note"*
+- working-tree drift: *"Do not trust a static list here… check live state directly"*
+- the production-caution guideline
+
+That pattern — tell Claude *how to find truth* instead of freezing a snapshot — is exactly the judgment-over-rules idea. Keep all of it.
+
+### The trimmable half (inferable from the file tree)
+
+- **`Technology Stack` (L10–16)**, **`Project Structure` (L18–30)**, **`Required Perl Modules` (L70–78)**, **`Architecture Notes` (L79–87)** — Claude reads this straight off the repo. Don't spend tokens on what's inferable from structure; spend them on gotchas (which this file otherwise does well).
+
+## Suggested action
+
+Drop the four structural/stack sections; keep the live-state gotchas + production guideline. ~113 → ~50 lines, and signal-to-noise on the parts that matter goes way up. Production repo — doc-only change, apply via the normal branch/PR flow when convenient.


### PR DESCRIPTION
Production is a direct `origin/main` checkout on orange (verified live 2026-08-28). CLAUDE.md's branch section now says so, documents the actual deploy steps (pull + graceful + migrations when a PR adds them), and marks `resp2`/`resp2-live-snapshot` as archives. `promote/live-state` — fully merged, zero unique commits, and the source of today's stale deploy assumption — has been deleted from origin; its sync-branch README existed only on that branch, and its one live note (Board.pm mkdir 0777) is preserved under Known Local Deviations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtYEpRABDMRnarLXqq8Tej