### PR TITLE
feat(poll): cross-tab vs 기수 (adaptive cohort bands), link entry points, vote-first gate message

### DIFF
--- a/board/edit.cgi
+++ b/board/edit.cgi
@@ -48,6 +48,9 @@ $ui->tparam(board_title=>$xb->title);
 $ui->tparam(owner=>[{name=>$xb->name, id=>$xb->id}] );
 $ui->tparam(img=>$img);
 $ui->tparam(member=>1);
+# _pollset.tmpl hides its cross-tab link here -- navigating away
+# mid-edit would lose the unsaved title/body
+$ui->tparam(edit_page=>1);
 
 my $allow_attach = $xb->allow_attach || 0;
 my $AllowAttach = $ui->cfg->AllowAttach || 0;

--- a/board/poll.cgi
+++ b/board/poll.cgi
@@ -16,6 +16,11 @@ unless ($auth->auth) {
 }
 my ($bid, $aid, $pid, $oid, $del, $mode)
     = map { $ui->cparam($_) || '' } qw(bid aid pid oid del mode);
+# force numeric ids up front (read.cgi's pattern): both are reflected
+# into the xtab link hrefs, so a non-numeric value must die here, not
+# ride a MariaDB leading-digit coercion into the rendered page.
+$bid = 0 unless ($bid =~ /^\d+$/);
+$aid = 0 unless ($aid =~ /^\d+$/);
 
 if ($bid && $aid) {
     my $uid = $auth->uid;
@@ -83,11 +88,17 @@ if ($bid && $aid) {
     $ui->tparam(board_id=>$bid);
     # cross-tab entry links: every poll pair plus each poll x 기수 (the
     # ki axis is what gives a single-poll article a cross-tab at all).
-    # Plain GET links, no script -- read.cgi's inline block lands here.
+    # Plain GET links, no script -- the 교차분석 link _pollset.tmpl
+    # renders inside read.cgi's article page navigates here. Tally-
+    # hidden election polls are skipped: their cross-tabs are refused
+    # server-side, and a link into a silent refusal is the blank the
+    # gated flag was invented to kill.
     if ($pollset && @$pollset) {
         my @xlink;
         foreach my $i (0 .. $#$pollset) {
+            next if (Bawi::Board::is_tally_hidden($$pollset[$i]{poll_id}));
             foreach my $j ($i + 1 .. $#$pollset) {
+                next if (Bawi::Board::is_tally_hidden($$pollset[$j]{poll_id}));
                 push @xlink,
                      { label=>sprintf('%d × %d', $i + 1, $j + 1),
                        href=>qq(poll.cgi?bid=$bid;aid=$aid;mode=xtab)

--- a/board/poll.cgi
+++ b/board/poll.cgi
@@ -81,20 +81,46 @@ if ($bid && $aid) {
     $ui->tparam(pollset=>$pollset);
     $ui->tparam(article_id=>$aid);
     $ui->tparam(board_id=>$bid);
-    $ui->tparam(xtab_form=>1) if ($pollset && @$pollset > 1);
+    # cross-tab entry links: every poll pair plus each poll x 기수 (the
+    # ki axis is what gives a single-poll article a cross-tab at all).
+    # Plain GET links, no script -- read.cgi's inline block lands here.
+    if ($pollset && @$pollset) {
+        my @xlink;
+        foreach my $i (0 .. $#$pollset) {
+            foreach my $j ($i + 1 .. $#$pollset) {
+                push @xlink,
+                     { label=>sprintf('%d × %d', $i + 1, $j + 1),
+                       href=>qq(poll.cgi?bid=$bid;aid=$aid;mode=xtab)
+                            .qq(;p1=$$pollset[$i]{poll_id};p2=$$pollset[$j]{poll_id}) };
+            }
+            push @xlink,
+                 { label=>sprintf('%d × 기수', $i + 1),
+                   href=>qq(poll.cgi?bid=$bid;aid=$aid;mode=xtab)
+                        .qq(;p1=$$pollset[$i]{poll_id};p2=ki) };
+        }
+        $ui->tparam(xtab_links=>\@xlink);
+    }
     if ($mode eq 'xtab') {
         my ($p1, $p2) = map { $ui->cparam($_) || '' } qw(p1 p2);
         my $xtab;
-        $xtab = $xb->get_poll_xtab(-poll_id1=>$p1, -poll_id2=>$p2,
-                                   -board_id=>$bid, -article_id=>$aid,
-                                   -uid=>$uid)
-            if ($p1 =~ /^\d+$/ && $p2 =~ /^\d+$/ &&
-                $bid =~ /^\d+$/ && $aid =~ /^\d+$/);
+        if ($p1 =~ /^\d+$/ && $bid =~ /^\d+$/ && $aid =~ /^\d+$/) {
+            if ($p2 eq 'ki') {
+                $xtab = $xb->get_poll_ki_xtab(-poll_id=>$p1, -board_id=>$bid,
+                                              -article_id=>$aid, -uid=>$uid);
+                $ui->tparam(xtab_ki=>1) if ($xtab);
+            } elsif ($p2 =~ /^\d+$/) {
+                $xtab = $xb->get_poll_xtab(-poll_id1=>$p1, -poll_id2=>$p2,
+                                           -board_id=>$bid, -article_id=>$aid,
+                                           -uid=>$uid);
+            }
+        }
         if ($xtab) {
             $ui->tparam(xtab=>1);
             $ui->tparam(xtab_poll1=>$$xtab{poll1});
             $ui->tparam(xtab_poll2=>$$xtab{poll2});
-            if ($$xtab{suppressed}) {
+            if ($$xtab{gated}) {
+                $ui->tparam(xtab_gated=>1);
+            } elsif ($$xtab{suppressed}) {
                 $ui->tparam(xtab_suppressed=>1);
             } else {
                 # loop params must never be set to a scalar/undef --

--- a/board/skin/default/_pollset.tmpl
+++ b/board/skin/default/_pollset.tmpl
@@ -46,9 +46,11 @@
 </table>
 
 </form>
-  <tmpl_unless __last__>
+  <tmpl_if __last__>
+<div class="xtab-link"><a href="poll.cgi?bid=<tmpl_var board_id>;aid=<tmpl_var article_id>">교차분석</a></div>
+  <tmpl_else>
 <br />
-  </tmpl_unless>
+  </tmpl_if>
   </tmpl_loop>
 <tmpl_else>
 No more poll.

--- a/board/skin/default/_pollset.tmpl
+++ b/board/skin/default/_pollset.tmpl
@@ -47,7 +47,9 @@
 
 </form>
   <tmpl_if __last__>
+    <tmpl_unless edit_page>
 <div class="xtab-link"><a href="poll.cgi?bid=<tmpl_var board_id>;aid=<tmpl_var article_id>">교차분석</a></div>
+    </tmpl_unless>
   <tmpl_else>
 <br />
   </tmpl_if>

--- a/board/skin/default/poll.tmpl
+++ b/board/skin/default/poll.tmpl
@@ -16,7 +16,7 @@
 <tr class="option">
   <td class="option">
   <tmpl_loop xtab_links>
-    <a href="<tmpl_var href>"><tmpl_var label></a>&nbsp;
+    <a href="<tmpl_var name=href escape=html>"><tmpl_var label></a>&nbsp;
   </tmpl_loop>
   </td>
 </tr>
@@ -28,21 +28,21 @@
 <table class="poll">
 <tmpl_if xtab_gated>
 <tr class="head">
-  <td class="head"><tmpl_var xtab_poll1> &times; <tmpl_var xtab_poll2></td>
+  <td class="head"><tmpl_var name=xtab_poll1 escape=html> &times; <tmpl_var name=xtab_poll2 escape=html></td>
 </tr>
 <tr class="bottom">
   <td>아직 투표하지 않은 설문이 있어 교차분석을 볼 수 없습니다. 투표 후 이용해 주세요.</td>
 </tr>
 <tmpl_else><tmpl_if xtab_suppressed>
 <tr class="head">
-  <td class="head"><tmpl_var xtab_poll1> &times; <tmpl_var xtab_poll2></td>
+  <td class="head"><tmpl_var name=xtab_poll1 escape=html> &times; <tmpl_var name=xtab_poll2 escape=html></td>
 </tr>
 <tr class="bottom">
   <td>응답 수 3명 미만인 조합이 있어 교차분석을 표시하지 않습니다.</td>
 </tr>
 <tmpl_else>
 <tr class="head">
-  <td class="head"><tmpl_var xtab_poll1> &times; <tmpl_var xtab_poll2></td>
+  <td class="head"><tmpl_var name=xtab_poll1 escape=html> &times; <tmpl_var name=xtab_poll2 escape=html></td>
   <tmpl_loop xtab_cols>
   <td class="head"><tmpl_var opt></td>
   </tmpl_loop>

--- a/board/skin/default/poll.tmpl
+++ b/board/skin/default/poll.tmpl
@@ -7,40 +7,33 @@
 <tmpl_include _pollset.tmpl>
 
 <tmpl_unless ajax>
-<tmpl_if xtab_form>
+<tmpl_if xtab_links>
 <br />
-<form id="poll-xtab" class="xtab" action="poll.cgi" method="get">
-<input type="hidden" name="bid" value="<tmpl_var board_id>" />
-<input type="hidden" name="aid" value="<tmpl_var article_id>" />
-<input type="hidden" name="mode" value="xtab" />
 <table class="poll">
 <tr class="head">
-  <td class="head" colspan="2">교차분석</td>
+  <td class="head">교차분석</td>
 </tr>
 <tr class="option">
   <td class="option">
-    <select name="p1">
-  <tmpl_loop pollset>
-      <option value="<tmpl_var poll_id>">Poll <tmpl_var __counter__>. <tmpl_var name=poll escape=html></option>
+  <tmpl_loop xtab_links>
+    <a href="<tmpl_var href>"><tmpl_var label></a>&nbsp;
   </tmpl_loop>
-    </select>
-    &times;
-    <select name="p2">
-  <tmpl_loop pollset>
-      <option value="<tmpl_var poll_id>">Poll <tmpl_var __counter__>. <tmpl_var name=poll escape=html></option>
-  </tmpl_loop>
-    </select>
   </td>
-  <td class="button"><input type="submit" value="교차분석" /></td>
 </tr>
 </table>
-</form>
 </tmpl_if>
 
 <tmpl_if xtab>
 <br />
 <table class="poll">
-<tmpl_if xtab_suppressed>
+<tmpl_if xtab_gated>
+<tr class="head">
+  <td class="head"><tmpl_var xtab_poll1> &times; <tmpl_var xtab_poll2></td>
+</tr>
+<tr class="bottom">
+  <td>아직 투표하지 않은 설문이 있어 교차분석을 볼 수 없습니다. 투표 후 이용해 주세요.</td>
+</tr>
+<tmpl_else><tmpl_if xtab_suppressed>
 <tr class="head">
   <td class="head"><tmpl_var xtab_poll1> &times; <tmpl_var xtab_poll2></td>
 </tr>
@@ -64,11 +57,16 @@
   </tmpl_loop>
 <tr class="bottom">
   <td colspan="<tmpl_var xtab_colspan>">
+<tmpl_if xtab_ki>
+    기수 등록 응답자: <tmpl_var xtab_n>명
+    (기수 정보가 없는 회원의 응답은 제외되어 총 응답수와 다를 수 있습니다)
+<tmpl_else>
     두 질문 모두 응답: <tmpl_var xtab_n>명
     (두 질문에 모두 응답한 사람 수라서 각 질문의 총 응답수와는 다를 수 있습니다)
+</tmpl_if>
   </td>
 </tr>
-</tmpl_if>
+</tmpl_if></tmpl_if>
 </table>
 </tmpl_if>
 </tmpl_unless>

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -21,6 +21,7 @@ $TBL{attach}    = 'bw_xboard_attach';
 $TBL{notice}    = 'bw_xboard_notice';
 $TBL{passwd}    = 'bw_xauth_passwd';
 $TBL{sig}       = 'bw_user_sig';
+$TBL{ki}        = 'bw_user_ki';
 $TBL{group}     = 'bw_group';
 $TBL{poll}      = 'bw_xboard_poll';
 $TBL{opt}       = 'bw_xboard_poll_opt';
@@ -2644,9 +2645,12 @@ sub get_poll_xtab {
                    $$poll1{article_id} == $aid &&
                    $$poll2{article_id} == $aid);
     # _pollset hides an open poll's results until the viewer answered;
-    # the cross-tab must not show joint counts any earlier.
-    return unless (($$poll1{is_closed} || &is_answered($p1, $uid)) &&
-                   ($$poll2{is_closed} || &is_answered($p2, $uid)));
+    # the cross-tab must not show joint counts any earlier. A flagged
+    # return (not bare undef) lets the page say WHY nothing is shown --
+    # the silent blank confused even the feature's own field testing.
+    return { poll1=>$$poll1{poll}, poll2=>$$poll2{poll}, gated=>1 }
+        unless (($$poll1{is_closed} || &is_answered($p1, $uid)) &&
+                ($$poll2{is_closed} || &is_answered($p2, $uid)));
 
     my $sql2 = qq(SELECT a1.opt_id, a2.opt_id, count(*)
                   FROM $TBL{ans} as a1 JOIN $TBL{ans} as a2 USING (uid)
@@ -2679,6 +2683,91 @@ sub get_poll_xtab {
     return { poll1=>$$poll1{poll}, poll2=>$$poll2{poll}, suppressed=>1 }
         if ($small);
     return { poll1=>$$poll1{poll}, poll2=>$$poll2{poll},
+             cols=>\@col, rows=>\@row, n=>$n,
+             colspan=>scalar(@col) + 1 };
+}
+
+sub get_poll_ki_xtab {
+    my ($self, %arg) = @_;
+    return unless (exists $arg{-poll_id} &&
+                   exists $arg{-board_id} && exists $arg{-article_id});
+
+    my $pid = $arg{-poll_id} || 0;
+    my $bid = $arg{-board_id} || 0;
+    my $aid = $arg{-article_id} || 0;
+    my $uid = $arg{-uid} || 0;
+    return if (&is_tally_hidden($pid));
+
+    my $sql = qq(SELECT poll_id, board_id, article_id, poll,
+                        closed < now() as is_closed
+                 FROM $TBL{poll}
+                 WHERE poll_id=?);
+    my $poll = $DBH->selectrow_hashref($sql, undef, $pid);
+    # bind the poll to the board/article the caller was authorized for,
+    # exactly as get_poll_xtab does.
+    return unless ($poll &&
+                   $$poll{board_id}   == $bid &&
+                   $$poll{article_id} == $aid);
+    return { poll1=>$$poll{poll}, poll2=>'기수', gated=>1 }
+        unless ($$poll{is_closed} || &is_answered($pid, $uid));
+
+    # ki 0 means "no cohort registered" -- those answers stay out of the
+    # table (and out of n; the footer says so) rather than forming a
+    # fake cohort column.
+    my $sql2 = qq(SELECT a.opt_id, k.ki, count(*)
+                  FROM $TBL{ans} as a JOIN $TBL{ki} as k USING (uid)
+                  WHERE a.poll_id=? && k.ki > 0
+                  GROUP BY 1, 2);
+    my $rv = $DBH->selectall_arrayref($sql2, undef, $pid);
+    my %cnt;
+    my $n = 0;
+    foreach my $i (@$rv) {
+        $cnt{$$i[1]}{$$i[0]} = $$i[2];
+        $n += $$i[2];
+    }
+
+    my $opt = &get_optset($pid, 0, 0);
+    # Adaptive banding instead of get_poll_xtab's all-or-nothing rule:
+    # seed one band per ki, then while any populated cell holds 1-2
+    # voters (few enough to name individuals), merge that band into a
+    # neighbor. Coarsening beats refusing here because the worst case --
+    # a single band -- just reproduces the public per-option tally, so
+    # every reachable state leaks nothing new; and unlike masking single
+    # cells, merged bands can't be solved back from the public marginals.
+    my @band = map  { { lo=>$_, hi=>$_, cnt=>$cnt{$_} } }
+               sort { $a <=> $b } keys %cnt;
+    my $again = 1;
+    while ($again && @band > 1) {
+        $again = 0;
+        foreach my $b (0 .. $#band) {
+            my $small = 0;
+            foreach my $o (@$opt) {
+                my $c = $band[$b]{cnt}{$$o{opt_id}} || 0;
+                ++$small if ($c && $c < 3);
+            }
+            next unless ($small);
+            my $into = $b ? $b - 1 : 1;
+            foreach my $k (keys %{$band[$b]{cnt}}) {
+                $band[$into]{cnt}{$k} += $band[$b]{cnt}{$k};
+            }
+            $band[$into]{lo} = $band[$b]{lo} if ($band[$b]{lo} < $band[$into]{lo});
+            $band[$into]{hi} = $band[$b]{hi} if ($band[$b]{hi} > $band[$into]{hi});
+            splice(@band, $b, 1);
+            # band indexes shifted; rescan from the start
+            $again = 1;
+            last;
+        }
+    }
+
+    my @col = map { { opt=>$$_{lo} == $$_{hi} ? qq($$_{lo}기)
+                                              : qq($$_{lo}~$$_{hi}기) } }
+              @band;
+    my @row;
+    foreach my $i (@$opt) {
+        my @cell = map { { cnt=>$$_{cnt}{$$i{opt_id}} || 0 } } @band;
+        push @row, { opt=>$$i{opt}, cell=>\@cell };
+    }
+    return { poll1=>$$poll{poll}, poll2=>'기수',
              cols=>\@col, rows=>\@row, n=>$n,
              colspan=>scalar(@col) + 1 };
 }

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -2583,15 +2583,13 @@ sub get_optset {
                 $_->{allow_vote} = $allow_vote;
 
                 #####TEMP CODE#####
-                #if ($pid == 1427) {
-                #if ($pid == 9696 || $pid == 9698) {
-                # if ($pid == 9857) {  ## 13대 동창회장 선거
-                # if ($pid == 9884 || $pid == 9886) { ## 14대 동창회장 선거
-                if ( $pid == 1427 ||
-                     $pid == 9696 || $pid == 9698 || ## 11대 동창회장 선거
-                     $pid == 9804 || ## 12대 동창회장 선거
-                     $pid == 9857 || ## 13대 동창회장 선거
-                     $pid == 9884 || $pid == 9886 )  ## 14대 동창회장 선거
+                # the hidden-election pid list lives ONLY in
+                # is_tally_hidden below -- add a new election's pids
+                # THERE. This used to be a second literal copy of the
+                # list; the xtab paths (which refuse from the same
+                # list) turned any drift between the copies into a
+                # one-click tally reconstruction, so it was deduped.
+                if (&is_tally_hidden($pid))
                 {
                     $_->{pct} = '';
                     $_->{width} = '';
@@ -2603,9 +2601,10 @@ sub get_optset {
 }
 
 sub is_tally_hidden {
-    # election polls whose tallies are policy-hidden: get_optset blanks
-    # their counts (TEMP CODE above), and get_poll_xtab refuses them
-    # outright -- a raw cross-tab would reconstruct the hidden numbers.
+    # THE single source of the hidden-election pid list: get_optset
+    # blanks their counts from it, both xtab paths refuse them, and
+    # poll.cgi skips their entry links. Add each new election's pids
+    # here and nowhere else.
     my $pid = shift || 0;
     return scalar grep { $pid == $_ }
         (1427,
@@ -2722,6 +2721,8 @@ sub get_poll_ki_xtab {
     my %cnt;
     my $n = 0;
     foreach my $i (@$rv) {
+        # keyed ki-first (the inverse of get_poll_xtab's row-first %cnt)
+        # because banding consumes whole per-ki slices below
         $cnt{$$i[1]}{$$i[0]} = $$i[2];
         $n += $$i[2];
     }
@@ -2730,10 +2731,12 @@ sub get_poll_ki_xtab {
     # Adaptive banding instead of get_poll_xtab's all-or-nothing rule:
     # seed one band per ki, then while any populated cell holds 1-2
     # voters (few enough to name individuals), merge that band into a
-    # neighbor. Coarsening beats refusing here because the worst case --
-    # a single band -- just reproduces the public per-option tally, so
-    # every reachable state leaks nothing new; and unlike masking single
-    # cells, merged bands can't be solved back from the public marginals.
+    # neighbor. Unlike masking single cells, merged bands can't be
+    # solved back from the public marginals; whatever merging can't fix
+    # (a lone sparse band, a 1-2 voter ki-less remainder) the terminal
+    # check below suppresses outright. Accepted residual: boundaries
+    # are data-derived, so a merged label certifies its sub-cohorts
+    # were sparse -- a <=2-sized constraint, proportionate here.
     my @band = map  { { lo=>$_, hi=>$_, cnt=>$cnt{$_} } }
                sort { $a <=> $b } keys %cnt;
     my $again = 1;
@@ -2746,7 +2749,9 @@ sub get_poll_ki_xtab {
                 ++$small if ($c && $c < 3);
             }
             next unless ($small);
-            my $into = $b ? $b - 1 : 1;
+            # merge into the left (adjacent-cohort) neighbor; band 0
+            # has no left neighbor, so it merges right
+            my $into = $b > 0 ? $b - 1 : 1;
             foreach my $k (keys %{$band[$b]{cnt}}) {
                 $band[$into]{cnt}{$k} += $band[$b]{cnt}{$k};
             }
@@ -2758,6 +2763,31 @@ sub get_poll_ki_xtab {
             last;
         }
     }
+
+    # Terminal safety net. The merge loop's invariant (every populated
+    # cell >= 3) holds only for multi-band exits; a single-band exit can
+    # still carry a 1-2 voter cell -- and that is NOT the public tally:
+    # the label names the observed cohort range and the counts exclude
+    # ki-less voters, so a 1-voter cell pins one member's vote to their
+    # cohort. Suppress instead, the sibling's rule at band granularity.
+    return { poll1=>$$poll{poll}, poll2=>'기수', suppressed=>1 }
+        unless ($n);
+    foreach my $b (@band) {
+        foreach my $o (@$opt) {
+            my $c = $$b{cnt}{$$o{opt_id}} || 0;
+            return { poll1=>$$poll{poll}, poll2=>'기수', suppressed=>1 }
+                if ($c && $c < 3);
+        }
+    }
+    # A 1-2 voter ki-less remainder is just as identifying: subtracting
+    # the table's column sums from the public per-option tally recovers
+    # those voters' options. Counted from the answers table (the public
+    # opt counters can drift historically and are not the anonymity set).
+    my $sql3 = qq(SELECT COUNT(*) FROM $TBL{ans} WHERE poll_id=?);
+    my ($tot) = $DBH->selectrow_array($sql3, undef, $pid);
+    my $rest = ($tot || 0) - $n;
+    return { poll1=>$$poll{poll}, poll2=>'기수', suppressed=>1 }
+        if ($rest > 0 && $rest < 3);
 
     my @col = map { { opt=>$$_{lo} == $$_{hi} ? qq($$_{lo}기)
                                               : qq($$_{lo}~$$_{hi}기) } }

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -35,6 +35,10 @@
 #      vote creates the option once (dedup) recording every answer, the
 #      0-seed poll renders without a phantom option row, and a fixed
 #      poll keeps a literal "0" seed option
+#   7  poll cross-tabs: the read page links to poll.cgi, an unvoted
+#      viewer gets the gated message (not silence), the poll x poll
+#      matrix renders, the <3 whole-table suppression still fires, and
+#      the poll x ki axis adaptively merges sparse cohorts into bands
 #
 # Conventions: POSIX sh + curl + docker compose only. fetch/login mutate
 # current-shell state ($CODE, $JAR) and abort via fail() -- call them bare,
@@ -48,7 +52,7 @@
 set -u
 cd "$(dirname "$0")/.."
 
-EXPECTED=49
+EXPECTED=54
 PASS='test1234'
 CANARY_ARTICLE='CANARY-ARTICLE-b7a2f9'
 CANARY_TITLE='CANARY-TITLE-c7d4e2'
@@ -743,6 +747,75 @@ got=$(db "SELECT COUNT(*) FROM bw_xboard_poll_opt WHERE poll_id=$zpid") || exit 
 got=$(db "SELECT COUNT(*) FROM bw_xboard_poll_ans WHERE poll_id=$zpid") || exit 1
 [ "$got" = "1" ] || fail "0-seed write-in vote not recorded (got '$got')"
 ok "0-seed write-in poll saves clean and takes its first write-in vote"
+
+# ======================================================= tier 7: cross-tabs
+# Fresh 2-poll article so no earlier tier's votes can pollute the cells.
+# Seeded ki is deterministic (uid N -> ki 10+N%25): tester02..05 carry ki
+# 12..15, tester06 carries 16 -- the band-label assertions depend on it.
+fetch "$J2" "$BASE/board/write.cgi" \
+      --data-urlencode "bid=2" \
+      --data-urlencode "title=xtab smoke" \
+      --data-urlencode "body=xtab host $$" \
+      --data-urlencode "poll=1" \
+      --data-urlencode "poll1=xtab q1 $$" \
+      --data-urlencode "poll1_1=xtA" \
+      --data-urlencode "poll1_2=xtB" \
+      --data-urlencode "poll2=xtab q2 $$" \
+      --data-urlencode "poll2_1=xtC" \
+      --data-urlencode "poll2_2=xtD" \
+      --data-urlencode "duration=7"
+[ "$CODE" = "302" ] || fail "xtab: write: HTTP $CODE"
+xaid=$(db "SELECT MAX(article_id) FROM bw_xboard_header WHERE board_id=2") || exit 1
+xp1=$(db "SELECT MIN(poll_id) FROM bw_xboard_poll WHERE article_id=$xaid") || exit 1
+xp2=$(db "SELECT MAX(poll_id) FROM bw_xboard_poll WHERE article_id=$xaid") || exit 1
+xoA=$(db "SELECT MIN(opt_id) FROM bw_xboard_poll_opt WHERE poll_id=$xp1") || exit 1
+xoB=$(db "SELECT MAX(opt_id) FROM bw_xboard_poll_opt WHERE poll_id=$xp1") || exit 1
+xoC=$(db "SELECT MIN(opt_id) FROM bw_xboard_poll_opt WHERE poll_id=$xp2") || exit 1
+xoD=$(db "SELECT MAX(opt_id) FROM bw_xboard_poll_opt WHERE poll_id=$xp2") || exit 1
+
+fetch "$J2" "$BASE/board/read.cgi?bid=2&aid=$xaid"
+[ "$CODE" = "200" ] || fail "xtab: read: HTTP $CODE"
+has "poll.cgi?bid=2;aid=$xaid" || fail "read page carries no cross-tab link"
+ok "article page links to the cross-tab entry page"
+
+login tester07; J7=$JAR
+fetch "$J7" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=$xp2"
+[ "$CODE" = "200" ] || fail "xtab gated: HTTP $CODE"
+has "투표 후 이용해 주세요" || fail "unvoted viewer got silence, not the gated message"
+ok "cross-tab before voting explains the gate instead of rendering nothing"
+
+for u in tester02 tester03 tester04 tester05; do
+    login "$u"
+    fetch "$JAR" "$BASE/board/poll.cgi" \
+          --data-urlencode "bid=2" --data-urlencode "aid=$xaid" \
+          --data-urlencode "pid=$xp1" --data-urlencode "oid=$xoA"
+    fetch "$JAR" "$BASE/board/poll.cgi" \
+          --data-urlencode "bid=2" --data-urlencode "aid=$xaid" \
+          --data-urlencode "pid=$xp2" --data-urlencode "oid=$xoC"
+done
+got=$(db "SELECT COUNT(*) FROM bw_xboard_poll_ans WHERE poll_id IN ($xp1,$xp2)") || exit 1
+[ "$got" = "8" ] || fail "xtab: expected 8 aligned answers (got '$got')"
+login tester02; J2=$JAR
+fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=$xp2"
+has "두 질문 모두 응답: 4명" || fail "poll x poll matrix did not render with n=4"
+ok "poll x poll cross-tab renders once every populated cell clears 3"
+
+fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=ki"
+has "12~15기" || fail "ki axis did not merge the sparse cohorts into 12~15기"
+has "기수 등록 응답자: 4명" || fail "ki footer missing or wrong n"
+ok "poll x ki adaptively merges 1-voter cohorts into one band"
+
+login tester06; J6=$JAR
+fetch "$J6" "$BASE/board/poll.cgi" \
+      --data-urlencode "bid=2" --data-urlencode "aid=$xaid" \
+      --data-urlencode "pid=$xp1" --data-urlencode "oid=$xoB"
+fetch "$J6" "$BASE/board/poll.cgi" \
+      --data-urlencode "bid=2" --data-urlencode "aid=$xaid" \
+      --data-urlencode "pid=$xp2" --data-urlencode "oid=$xoD"
+login tester02; J2=$JAR
+fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=$xp2"
+has "표시하지 않습니다" || fail "a 1-voter cell did not suppress the poll x poll table"
+ok "poll x poll whole-table <3 suppression still fires"
 
 [ "$N" -eq "$EXPECTED" ] || fail "ran $N of $EXPECTED checks -- a check was skipped or removed without updating EXPECTED"
 echo "all $N checks passed"

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -815,7 +815,10 @@ ok "poll x ki adaptively merges 1-voter cohorts into one band"
 # a dense cohort must keep 1-ki resolution while sparse neighbors merge:
 # fabricate a 3-voter ki-40 cohort by direct insert. The synthetic uids
 # answer poll 1 only, so the poll x poll cross-tab (a self-join over
-# BOTH polls) never sees them.
+# BOTH polls) never sees them. DELETE first: bw_user_ki's uid PK would
+# otherwise kill an unseeded rerun with a raw duplicate-entry error
+# (stale poll_ans rows are harmless -- they belong to dead poll_ids).
+db "DELETE FROM bw_user_ki WHERE uid IN (9001,9002,9003)" || exit 1
 for u in 9001 9002 9003; do
     db "INSERT INTO bw_user_ki (uid, ki) VALUES ($u, 40)" || exit 1
     db "INSERT INTO bw_xboard_poll_ans (poll_id, uid, opt_id) VALUES ($xp1, $u, $xoA)" || exit 1
@@ -832,6 +835,10 @@ fetch "$J6" "$BASE/board/poll.cgi" \
 fetch "$J6" "$BASE/board/poll.cgi" \
       --data-urlencode "bid=2" --data-urlencode "aid=$xaid" \
       --data-urlencode "pid=$xp2" --data-urlencode "oid=$xoD"
+# pin that both stray votes landed (8 prior + 3 synthetic + these 2) --
+# otherwise a silently dropped vote misreads as an app suppression bug
+got=$(db "SELECT COUNT(*) FROM bw_xboard_poll_ans WHERE poll_id IN ($xp1,$xp2)") || exit 1
+[ "$got" = "13" ] || fail "xtab: tester06 votes did not land (got '$got')"
 login tester02; J2=$JAR
 fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=$xp2"
 has "표시하지 않습니다" || fail "a 1-voter cell did not suppress the poll x poll table"

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -38,7 +38,10 @@
 #   7  poll cross-tabs: the read page links to poll.cgi, an unvoted
 #      viewer gets the gated message (not silence), the poll x poll
 #      matrix renders, the <3 whole-table suppression still fires, and
-#      the poll x ki axis adaptively merges sparse cohorts into bands
+#      the poll x ki axis adaptively merges sparse cohorts into bands --
+#      dense cohorts standing alone (multi-band render), a sparse
+#      single band suppressing instead of publishing, and a 1-2 voter
+#      ki-less remainder suppressing (the subtraction guard)
 #
 # Conventions: POSIX sh + curl + docker compose only. fetch/login mutate
 # current-shell state ($CODE, $JAR) and abort via fail() -- call them bare,
@@ -52,7 +55,7 @@
 set -u
 cd "$(dirname "$0")/.."
 
-EXPECTED=54
+EXPECTED=57
 PASS='test1234'
 CANARY_ARTICLE='CANARY-ARTICLE-b7a2f9'
 CANARY_TITLE='CANARY-TITLE-c7d4e2'
@@ -750,8 +753,10 @@ ok "0-seed write-in poll saves clean and takes its first write-in vote"
 
 # ======================================================= tier 7: cross-tabs
 # Fresh 2-poll article so no earlier tier's votes can pollute the cells.
-# Seeded ki is deterministic (uid N -> ki 10+N%25): tester02..05 carry ki
-# 12..15, tester06 carries 16 -- the band-label assertions depend on it.
+# Seeded ki is deterministic (uid N -> ki 10+N%25; root/uid 1 is ki 1):
+# tester02..05 carry ki 12..15, tester06 carries 16 -- the band-label
+# assertions depend on it. Every seeded cohort has at most 2 members, so
+# dense (>=3 voter) cohorts are fabricated by direct insert where needed.
 fetch "$J2" "$BASE/board/write.cgi" \
       --data-urlencode "bid=2" \
       --data-urlencode "title=xtab smoke" \
@@ -765,6 +770,8 @@ fetch "$J2" "$BASE/board/write.cgi" \
       --data-urlencode "poll2_2=xtD" \
       --data-urlencode "duration=7"
 [ "$CODE" = "302" ] || fail "xtab: write: HTTP $CODE"
+# id recovery: MIN = first seeded (poll1 / options xtA,xtC), MAX = the
+# second (poll2 / xtB,xtD) -- same insertion-order rule tier 6 documents
 xaid=$(db "SELECT MAX(article_id) FROM bw_xboard_header WHERE board_id=2") || exit 1
 xp1=$(db "SELECT MIN(poll_id) FROM bw_xboard_poll WHERE article_id=$xaid") || exit 1
 xp2=$(db "SELECT MAX(poll_id) FROM bw_xboard_poll WHERE article_id=$xaid") || exit 1
@@ -805,6 +812,19 @@ has "12~15기" || fail "ki axis did not merge the sparse cohorts into 12~15기"
 has "기수 등록 응답자: 4명" || fail "ki footer missing or wrong n"
 ok "poll x ki adaptively merges 1-voter cohorts into one band"
 
+# a dense cohort must keep 1-ki resolution while sparse neighbors merge:
+# fabricate a 3-voter ki-40 cohort by direct insert. The synthetic uids
+# answer poll 1 only, so the poll x poll cross-tab (a self-join over
+# BOTH polls) never sees them.
+for u in 9001 9002 9003; do
+    db "INSERT INTO bw_user_ki (uid, ki) VALUES ($u, 40)" || exit 1
+    db "INSERT INTO bw_xboard_poll_ans (poll_id, uid, opt_id) VALUES ($xp1, $u, $xoA)" || exit 1
+done
+fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=ki"
+has "12~15기" || fail "sparse cohorts no longer merge once a dense band exists"
+has "40기" || fail "a 3-voter cohort did not stand as its own band"
+ok "dense cohorts stand alone while sparse neighbors merge (multi-band render)"
+
 login tester06; J6=$JAR
 fetch "$J6" "$BASE/board/poll.cgi" \
       --data-urlencode "bid=2" --data-urlencode "aid=$xaid" \
@@ -816,6 +836,45 @@ login tester02; J2=$JAR
 fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=$xp2"
 has "표시하지 않습니다" || fail "a 1-voter cell did not suppress the poll x poll table"
 ok "poll x poll whole-table <3 suppression still fires"
+
+# the same stray vote poisons the ki axis: 16기's lone B answer drags
+# every band into one that still holds a 1-voter cell -- the terminal
+# check must suppress it, never publish (the single-band state is NOT
+# the public tally: it is cohort-labeled and excludes ki-less voters)
+fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=ki"
+has "표시하지 않습니다" || fail "a sparse single-band ki table was published (terminal suppression missing)"
+ok "a ki table that cannot merge itself safe is suppressed"
+
+# ki-less remainder: when public answers exceed the ki table's n by 1-2,
+# subtracting column sums from the public tally pins those voters. Three
+# registered voters render fine; one ki-less answer must flip the table
+# to suppressed.
+fetch "$J2" "$BASE/board/write.cgi" \
+      --data-urlencode "bid=2" \
+      --data-urlencode "title=kiless smoke" \
+      --data-urlencode "body=kiless host $$" \
+      --data-urlencode "poll=1" \
+      --data-urlencode "poll1=kiless q $$" \
+      --data-urlencode "poll1_1=klA" \
+      --data-urlencode "poll1_2=klB" \
+      --data-urlencode "duration=7"
+[ "$CODE" = "302" ] || fail "kiless: write: HTTP $CODE"
+kaid=$(db "SELECT MAX(article_id) FROM bw_xboard_header WHERE board_id=2") || exit 1
+kpid=$(db "SELECT MAX(poll_id) FROM bw_xboard_poll WHERE article_id=$kaid") || exit 1
+koA=$(db "SELECT MIN(opt_id) FROM bw_xboard_poll_opt WHERE poll_id=$kpid") || exit 1
+for u in tester02 tester03 tester04; do
+    login "$u"
+    fetch "$JAR" "$BASE/board/poll.cgi" \
+          --data-urlencode "bid=2" --data-urlencode "aid=$kaid" \
+          --data-urlencode "pid=$kpid" --data-urlencode "oid=$koA"
+done
+login tester02; J2=$JAR
+fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$kaid&mode=xtab&p1=$kpid&p2=ki"
+has "기수 등록 응답자: 3명" || fail "kiless precondition: 3-voter table did not render"
+db "INSERT INTO bw_xboard_poll_ans (poll_id, uid, opt_id) VALUES ($kpid, 9010, $koA)" || exit 1
+fetch "$J2" "$BASE/board/poll.cgi?bid=2&aid=$kaid&mode=xtab&p1=$kpid&p2=ki"
+has "표시하지 않습니다" || fail "a 1-voter ki-less remainder did not suppress the ki table"
+ok "a 1-2 voter ki-less remainder suppresses the ki table (subtraction guard)"
 
 [ "$N" -eq "$EXPECTED" ] || fail "ran $N of $EXPECTED checks -- a check was skipped or removed without updating EXPECTED"
 echo "all $N checks passed"


### PR DESCRIPTION
Extends the PR #29 cross-tab: a poll can now be crossed against **기수** (member cohort, `bw_user_ki`), so even a single-poll article gets an analysis; entry links replace the two-select form and appear inline on the article page; and the "you haven't voted yet" state finally says so instead of rendering nothing.

## 1. Poll × 기수 with adaptive cohort bands — zero schema change

`get_poll_ki_xtab` treats ki as the second axis: one `JOIN bw_user_ki USING (uid)` grouped by `(opt_id, ki)`. The same board/article binding, `is_tally_hidden` refusal, and voted-or-closed viewing gate as `get_poll_xtab`.

**Why bands instead of the <3 whole-table rule:** the ki axis spans every cohort in the community, so some 기 with 1–2 voters is near-certain and the poll×poll suppression rule would blank the table essentially always. Instead, each ki seeds its own band and any band holding a 1–2 voter cell merges into its neighbor until every populated cell clears 3 — a dense cohort survives at 1-기 resolution ("14기"), sparse tails coarsen ("30~37기"). Nothing is masked, so nothing can be solved back from the public per-option marginals. What merging cannot fix, the terminal check **suppresses** (review round): a still-sparse single band (its cells are *not* the public tally — the label names the observed cohort range and the counts exclude ki-less voters), an empty table, and a 1–2 voter **ki-less remainder** (public answers − n, whose options are otherwise recoverable by subtracting the column sums from the public tally). `ki=0` (no registered cohort) answers stay out of the table and out of N; the footer says so. Accepted residual, stated in the code: band boundaries are data-derived, so a merged label certifies its sub-cohorts were sparse — a ≤2-sized constraint.

The poll×poll path and its all-or-nothing <3 rule are untouched — both its marginals are public, so masking/merging doesn't apply there.

## 2. Entry links: chips on poll.cgi, one inline link on the article page

- The two-`<select>` form is replaced by plain GET links — every poll pair plus each poll × 기수 (`1 × 2 · 1 × 기수 · 2 × 기수`). No script, and `p1`/`p2` validation now admits the literal `ki` for p2 only.
- `_pollset.tmpl` appends a single 교차분석 link after the last poll, so readers discover the page from the article itself. Built from loop context already in memory — **zero additional queries on the read path** (deliberate, after the #23–26 perf work; this is also why there is no association-strength "heatmap" coloring, which would cost N² joins per article view).

## 3. Gated state gets words

`get_poll_xtab`'s voted-or-closed gate returned bare undef, rendering silent nothing — which confused even this feature's own field testing. Both cross-tab paths now return a `gated` flag and the page explains: 「아직 투표하지 않은 설문이 있어 교차분석을 볼 수 없습니다. 투표 후 이용해 주세요.」

## Review round (codex + 8 deep-review agents)

Both HIGHs confirmed-then-fixed: the terminal single-band leak above (Codex P1 + 5 agent confirmations), and a **reflected XSS** via `aid` — cparam'd ids flowed unvalidated into the new link hrefs through an unescaped `tmpl_var`, with MariaDB coercing a payload's leading digits into a live article id; both ids are now numeric-forced at the top of poll.cgi (read.cgi's own pattern) and the href + poll-question renders carry `escape=html` (questions are stored raw, unlike options — pre-existing sinks in `_pollset.tmpl` noted below). MEDIUMs: the hidden-election pid list is **deduped** — `is_tally_hidden` is now the single source and `get_optset` consumes it (drift between the two copies would have been a one-click tally reconstruction via the new ki link); entry links **skip tally-hidden polls**; the inline 교차분석 link no longer renders on the **edit page** (mid-edit navigation loses unsaved work).

**Confirmatory round** (Codex + 3 agents, differential-tested): the terminal-suppression smoke checks FAIL against the pre-fix code (non-vacuous pins), live XSS payloads no longer reflect, no safe state over-suppresses, the `get_optset` dedup is behavior-identical, and a hand-trace of the merge algorithm matches every pinned band label. Zero HIGH/MEDIUM code findings; the suite gained rerun tolerance (DELETE-guard before the synthetic inserts — 57/57 passes twice without a reseed between) and a landed-vote pin for the stray-vote fixture.

Declined with reasons: template head-row dedup (the three branch bodies now all differ); literal × vs `&times;` in labels (cosmetic); insert-side escaping of poll questions (render-side fixes existing rows and touches no live write path); the inline 교차분석 link on articles whose polls are *all* tally-hidden (Codex P3 — gating it means threading an aggregate flag through every `get_pollset` call site, for 7 closed historical election articles); the ajax-vote-mid-edit link resurrection (pre-fix behavior on an obscure interaction). **Pre-existing, out of scope, flagged for a follow-up PR**: `_pollset.tmpl` renders the poll *question* raw on the article page (the render-side escaping here covers only the new xtab heads — a stored `<script>` in a question is a live pre-existing sink site-wide); `get_pollset(-article_id=>…)` does not bind the article to the authorized board (unchanged from main).

## Smoke tier 7 (EXPECTED 49 → 57)

First automated coverage for the cross-tab at all: the read-page link; the gated message (not silence) for an unvoted viewer; the poll×poll matrix rendering at n=4; the <3 whole-table suppression still firing after one stray vote; and the adaptive merge pinned exactly — seeded ki is deterministic (`uid → 10+uid%25`), so tester02–05's four 1-voter cohorts must merge to the literal band label `12~15기`.

Three review-round pins: a **multi-band render** (a fabricated 3-voter ki-40 cohort stands alone while the sparse testers merge — every seeded cohort has ≤2 members, so dense cohorts are made by direct insert), the **sparse single-band suppression** after the stray vote, and the **ki-less remainder flip** (a 3-voter table renders, one ki-less answer suppresses it). All 57 checks green locally (`docker compose up -d --build && ./seed/reseed.sh && sh t/smoke.sh`), plus browser-verified screenshots of the chip row, the merged-band matrix, the inline link, and the gated message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QypbetiNTUeKFGv8jRAGVY
