### PR TITLE
feat(board): inline [[첨부N]] body tokens — attachments placed in one save

### DIFF
--- a/board/skin/default/_attach.tmpl
+++ b/board/skin/default/_attach.tmpl
@@ -1,6 +1,7 @@
 <ol class="attach">
 <tmpl_loop attach>
   <li id="attach-<tmpl_var attach_id>">
+    <!-- the <ol> position is the N of the body token [[첨부N]] -->
     <a href="attach.cgi?atid=<tmpl_var attach_id>;name=/<tmpl_var filename>"><tmpl_var filename> (<tmpl_var filesize>)</a>
     <a href="detach.cgi?atid=<tmpl_var attach_id>;bid=<tmpl_var board_id>">x</a>
     <div>

--- a/board/skin/default/_write_form.tmpl
+++ b/board/skin/default/_write_form.tmpl
@@ -60,7 +60,9 @@
 </tr>
 <tr>
   <td class="label"></td>
-  <td><a class="button" id="attach-more">Attach a file</a></td>
+  <td><a class="button" id="attach-more">Attach a file</a>
+    <small>본문에 <code>[[첨부1]]</code>을 쓰면 첫 번째 첨부 파일이 그 자리에 표시됩니다</small>
+  </td>
 </tr>
 </tmpl_if>
 
@@ -73,6 +75,8 @@
   <tmpl_if image>
     <a href="attach.cgi?atid=<tmpl_var attach_id>" target="_blank"><img src="attach.cgi?atid=<tmpl_var attach_id>" alt="<tmpl_var filename>"></a>
     </tmpl_if>
+    <!-- the number is the N of the body token [[첨부N]] -->
+    <tmpl_var __counter__>.
     <a href="attach.cgi?atid=<tmpl_var attach_id>" target="_blank"><tmpl_var filename> (<tmpl_var filesize>)</a>
     <a href="detach.cgi?atid=<tmpl_var attach_id>&bid=<tmpl_var board_id>">x</a>
   </td>

--- a/board/skin/default/_write_form.tmpl
+++ b/board/skin/default/_write_form.tmpl
@@ -61,7 +61,7 @@
 <tr>
   <td class="label"></td>
   <td><a class="button" id="attach-more">Attach a file</a>
-    <small>본문에 <code>[[첨부1]]</code>을 쓰면 첫 번째 첨부 파일이 그 자리에 표시됩니다</small>
+    <small>본문에 <code>[[첨부1]]</code> 또는 <code>[[attach1]]</code>을 쓰면 첫 번째 첨부 파일이 그 자리에 표시됩니다</small>
   </td>
 </tr>
 </tmpl_if>

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -1246,15 +1246,30 @@ sub embed_attach_tokens {
     return $html unless ($html =~ /\[\[(?:첨부|attach)\d+\]\]/);
 
     my $attach = $self->get_attachset(-article_id=>$$article{article_id}) || [];
-    # never substitute inside code samples -- an article DEMONSTRATING
-    # the token would otherwise render an image in its own example.
-    # The strict no-spaces token doubles as the escape hatch elsewhere.
-    my @chunk = split(/(<pre\b.*?<\/pre>|<code\b.*?<\/code>)/s, $html);
-    foreach my $c (@chunk) {
-        next if ($c =~ /^<(?:pre|code)\b/);
-        $c =~ s/\[\[(?:첨부|attach)(\d+)\]\]/&attach_token_html($attach, $1)/ge;
+    # One linear pass over the rendered HTML. Substitute a token ONLY in
+    # text content: never inside an HTML tag (a token that landed in an
+    # attribute -- e.g. a markdown link's href="[[attach1]]" -- would be
+    # corrupted into a nested element) and never inside <pre>/<code>, so an
+    # article DEMONSTRATING the token still shows it literally. A single
+    # scan (not a paired-tag split) also avoids quadratic backtracking on a
+    # raw-HTML body, where unclosed <pre>/<code> openers are legal TEXT.
+    my $out = '';
+    my $skip = 0;   # >0 while inside one or more open pre/code regions
+    while ($html =~ /\G(.*?)(<[^>]*>|\[\[(?:첨부|attach)(\d+)\]\])/sgc) {
+        my ($text, $hit, $n) = ($1, $2, $3);
+        $out .= $text;
+        if (!defined $n) {
+            # an HTML tag -- emit verbatim, track pre/code nesting (any case)
+            if ($hit =~ /^<\s*(?:pre|code)\b/i)         { ++$skip }
+            elsif ($hit =~ /^<\s*\/\s*(?:pre|code)\b/i) { --$skip if ($skip) }
+            $out .= $hit;
+        }
+        else {
+            $out .= $skip ? $hit : &attach_token_html($attach, $n);
+        }
     }
-    return join('', @chunk);
+    $out .= substr($html, pos($html) // 0);
+    return $out;
 }
 
 sub attach_token_html {

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -1242,6 +1242,13 @@ sub embed_attach_tokens {
     # literal token and attach/detach can never serve stale ids. The
     # emitted markup carries only atid+filename (no author identity),
     # so the anonboard concern on make_hyperlink does not apply here.
+    #
+    # Accepted limitation (positional, not identity-bound): detaching a
+    # MIDDLE attachment silently reaims the later tokens down one slot
+    # (only a now-out-of-range tail token shows the visible marker). The
+    # compose-once flow this feature exists for never hits it; binding a
+    # token to a stable id would need a write-path rewrite that freezes
+    # later-added attachments -- deliberately not done.
     return $html unless (defined $html && $article && $$article{article_id});
     return $html unless ($html =~ /\[\[(?:첨부|attach)\d+\]\]/);
 
@@ -1253,6 +1260,11 @@ sub embed_attach_tokens {
     # article DEMONSTRATING the token still shows it literally. A single
     # scan (not a paired-tag split) also avoids quadratic backtracking on a
     # raw-HTML body, where unclosed <pre>/<code> openers are legal TEXT.
+    # <[^>]*> stays linear on purpose: a literal '>' inside a quoted
+    # attribute ends the tag early (a token right after it would be
+    # substituted), but that is malformed body HTML on an already-non-
+    # sanitizing surface -- not worth the char scanner a quote-aware match
+    # would need to stay linear.
     my $out = '';
     my $skip = 0;   # >0 while inside one or more open pre/code regions
     while ($html =~ /\G(.*?)(<[^>]*>|\[\[(?:첨부|attach)(\d+)\]\])/sgc) {

--- a/lib/Bawi/Board.pm
+++ b/lib/Bawi/Board.pm
@@ -1203,6 +1203,7 @@ sub format_article {
         $body = &escape_tags($self, $body);
         # keep in sync with t/markdown_smoke.pl (drift-checked there)
         $body =~ s/\shref\s*=\s*(["'])\s*(?:javascript|data|vbscript)\s*:[^"']*\1/ href="#"/gi;
+        $body = $self->embed_attach_tokens($body, $article);
         return $body;
     }
     my @body = split(/\r?\n/, $body);
@@ -1225,8 +1226,54 @@ sub format_article {
 
     #$body = join("\n", @body);
     $body = join("<br />\n", @body);
-    
+
+    $body = $self->embed_attach_tokens($body, $article);
     return $body;
+}
+
+sub embed_attach_tokens {
+    my ($self, $html, $article) = @_;
+    # [[첨부N]] / [[attachN]]: the article's N-th attachment (upload
+    # order), placed inline where the token sits. The body carries a
+    # POSITION, not an id -- at compose time the attach_id does not
+    # exist yet, which is exactly why authors could never inline their
+    # figures in one save. Resolution runs AFTER the mode renderers and
+    # AFTER the markdown cache, so bw_xboard_body_html keeps the
+    # literal token and attach/detach can never serve stale ids. The
+    # emitted markup carries only atid+filename (no author identity),
+    # so the anonboard concern on make_hyperlink does not apply here.
+    return $html unless (defined $html && $article && $$article{article_id});
+    return $html unless ($html =~ /\[\[(?:첨부|attach)\d+\]\]/);
+
+    my $attach = $self->get_attachset(-article_id=>$$article{article_id}) || [];
+    # never substitute inside code samples -- an article DEMONSTRATING
+    # the token would otherwise render an image in its own example.
+    # The strict no-spaces token doubles as the escape hatch elsewhere.
+    my @chunk = split(/(<pre\b.*?<\/pre>|<code\b.*?<\/code>)/s, $html);
+    foreach my $c (@chunk) {
+        next if ($c =~ /^<(?:pre|code)\b/);
+        $c =~ s/\[\[(?:첨부|attach)(\d+)\]\]/&attach_token_html($attach, $1)/ge;
+    }
+    return join('', @chunk);
+}
+
+sub attach_token_html {
+    my ($attach, $n) = @_;
+    my $a = $n > 0 ? $$attach[$n - 1] : undef;
+    # a detached or mistyped position must show loudly, not vanish
+    return qq(<span class="attach-missing">[첨부$n 없음]</span>)
+        unless ($a);
+    my $f = $$a{filename};
+    $f =~ s/&/&amp;/g;
+    $f =~ s/</&lt;/g;
+    $f =~ s/>/&gt;/g;
+    $f =~ s/"/&quot;/g;
+    # same URL shape and img class as _attach.tmpl's gallery, so the
+    # existing article-body fit-to-width CSS applies unchanged
+    my $src = qq(attach.cgi?atid=$$a{attach_id};name=/$f);
+    return $$a{image}
+        ? qq(<img class="internal" src="$src" alt="$f" />)
+        : qq(<a href="$src">$f</a>);
 }
 
 sub format_anon_list { 

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -57,7 +57,7 @@
 set -u
 cd "$(dirname "$0")/.."
 
-EXPECTED=59
+EXPECTED=60
 PASS='test1234'
 CANARY_ARTICLE='CANARY-ARTICLE-b7a2f9'
 CANARY_TITLE='CANARY-TITLE-c7d4e2'
@@ -703,6 +703,24 @@ fetch "$J2" "$BASE/board/read.cgi?bid=2&aid=$tpaid"
 has "<img class=\"internal\" src=\"attach.cgi?atid=$tp1" || fail "token plain: [[첨부1]] did not render inline"
 grep -qF "[첨부7 없음]" "$TMP/body" || fail "token plain: out-of-range token did not render the marker"
 ok "attachment tokens resolve in plain mode too"
+
+# token context safety: a token must stay LITERAL inside an HTML tag
+# (an attribute is not a substitution site -- it would corrupt the tag)
+# and inside an uppercase <PRE> block (the pre/code escape is case-
+# insensitive), while a bare token in text still resolves. Plain mode so
+# the raw HTML passes through verbatim (no markdown parsing to reason
+# about); board 2's escaped_tags denylist omits pre/b, so both survive.
+fetch "$J2" "$BASE/board/write.cgi" -F "bid=2" -F "title=token ctx smoke" \
+      -F "body=upper <PRE>[[첨부1]]</PRE> attr <b title=\"[[attach1]]\">x</b> text [[첨부1]] end $$" \
+      -F "attach_no=1" -F "attach1=@$TMP/att.png;type=image/png"
+[ "$CODE" = "302" ] || fail "token ctx: write: HTTP $CODE"
+tcaid=$(db "SELECT MAX(article_id) FROM bw_xboard_header WHERE board_id=2") || exit 1
+tc1=$(db "SELECT MAX(attach_id) FROM bw_xboard_attach WHERE article_id=$tcaid") || exit 1
+fetch "$J2" "$BASE/board/read.cgi?bid=2&aid=$tcaid"
+grep -qF "[[첨부1]]</PRE>" "$TMP/body" || fail "token ctx: token inside uppercase <PRE> was substituted"
+grep -qF 'title="[[attach1]]"' "$TMP/body" || fail "token ctx: token inside an HTML attribute was substituted"
+has "<img class=\"internal\" src=\"attach.cgi?atid=$tc1" || fail "token ctx: the bare text token did not resolve (positive control)"
+ok "attachment tokens stay literal inside tags and <PRE>, resolve in text"
 
 # ============================================================= tier 6: polls
 # Write-in polls: a poll with "voters may add an option" (uopt) needs NO

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -29,8 +29,10 @@
 #      saved + sibling + unrelated notes, manual unsend) + profile-link
 #      rendering and the anonboard negative
 #   5  attachments: upload -> detach round-trip (row/file/link), the
-#      ghost-row detach (file missing must not keep the row), and the
-#      ghost-image counter balance
+#      ghost-row detach (file missing must not keep the row), the
+#      ghost-image counter balance, and inline [[첨부N]]/[[attachN]]
+#      body tokens (render-time resolution in both body modes: img,
+#      link, visible out-of-range marker, code-block escape)
 #   6  polls: write-in (uopt) polls save with 1 or 0 seed options, the
 #      vote creates the option once (dedup) recording every answer, the
 #      0-seed poll renders without a phantom option row, and a fixed
@@ -55,7 +57,7 @@
 set -u
 cd "$(dirname "$0")/.."
 
-EXPECTED=57
+EXPECTED=59
 PASS='test1234'
 CANARY_ARTICLE='CANARY-ARTICLE-b7a2f9'
 CANARY_TITLE='CANARY-TITLE-c7d4e2'
@@ -658,6 +660,49 @@ got=$(db "SELECT COUNT(*) FROM bw_xboard_attach WHERE attach_id=$giatid") || exi
 img1=$(db "SELECT images FROM bw_xboard_board WHERE board_id=2") || exit 1
 [ "$img1" = "$img0" ] || fail "board image counter drifted on ghost-image detach ($img0 -> $img1)"
 ok "ghost-image detach keeps the board image counter balanced"
+
+# inline attachment tokens: [[첨부N]] / [[attachN]] resolve at render
+# time from the article's attachment list (position, not id -- the id
+# does not exist while composing). Markdown article: image token ->
+# inline img, non-image -> link, out-of-range -> visible marker, and a
+# token inside a fenced code block stays LITERAL (an article can
+# demonstrate its own syntax).
+printf 'token attach payload %s\n' "$$" > "$TMP/tok.txt"
+fetch "$J2" "$BASE/board/write.cgi" -F "bid=2" -F "title=token md smoke" \
+      -F "markup=1" \
+      -F "body=fig one: [[첨부1]]
+
+file two: [[attach2]]
+
+missing: [[첨부9]]
+
+\`\`\`
+[[첨부1]] shown literally
+\`\`\`" \
+      -F "attach_no=2" -F "attach1=@$TMP/att.png;type=image/png" -F "attach2=@$TMP/tok.txt"
+[ "$CODE" = "302" ] || fail "token md: write: HTTP $CODE"
+tkaid=$(db "SELECT MAX(article_id) FROM bw_xboard_header WHERE board_id=2") || exit 1
+tk1=$(db "SELECT MIN(attach_id) FROM bw_xboard_attach WHERE article_id=$tkaid") || exit 1
+tk2=$(db "SELECT MAX(attach_id) FROM bw_xboard_attach WHERE article_id=$tkaid") || exit 1
+fetch "$J2" "$BASE/board/read.cgi?bid=2&aid=$tkaid"
+has "<img class=\"internal\" src=\"attach.cgi?atid=$tk1" || fail "token md: [[첨부1]] did not render the first attachment inline"
+has "<a href=\"attach.cgi?atid=$tk2" || fail "token md: [[attach2]] did not render the non-image as a link"
+# grep -F: '[' opens a BRE bracket expression, so has() can't match these
+grep -qF "[첨부9 없음]" "$TMP/body" || fail "token md: out-of-range token did not render the visible marker"
+grep -qF "[[첨부1]] shown literally" "$TMP/body" || fail "token md: token inside a code block was substituted"
+ok "attachment tokens resolve in markdown mode (img, link, marker, code-block escape)"
+
+# plain (non-markdown) article: same tokens, same resolution
+fetch "$J2" "$BASE/board/write.cgi" -F "bid=2" -F "title=token plain smoke" \
+      -F "body=plain fig: [[첨부1]] and missing [[attach7]] host $$" \
+      -F "attach_no=1" -F "attach1=@$TMP/att.png;type=image/png"
+[ "$CODE" = "302" ] || fail "token plain: write: HTTP $CODE"
+tpaid=$(db "SELECT MAX(article_id) FROM bw_xboard_header WHERE board_id=2") || exit 1
+tp1=$(db "SELECT MAX(attach_id) FROM bw_xboard_attach WHERE article_id=$tpaid") || exit 1
+fetch "$J2" "$BASE/board/read.cgi?bid=2&aid=$tpaid"
+has "<img class=\"internal\" src=\"attach.cgi?atid=$tp1" || fail "token plain: [[첨부1]] did not render inline"
+grep -qF "[첨부7 없음]" "$TMP/body" || fail "token plain: out-of-range token did not render the marker"
+ok "attachment tokens resolve in plain mode too"
 
 # ============================================================= tier 6: polls
 # Write-in polls: a poll with "voters may add an option" (uopt) needs NO


### PR DESCRIPTION
Solves the one-save inlining problem: `attach_id` doesn't exist while composing, so placing a figure in the body always meant save → edit → copy the id → save again. The body now carries a **position, not an id**: `[[첨부1]]` (or `[[attach1]]`) means "this article's first attachment, upload order," resolved at render time from the attachment list the page already loads.

## Design

- **Mode-agnostic by construction**: `embed_attach_tokens` is the *final* pass of `format_article`, after whichever renderer ran — plain and markdown produce identical figure markup, and the token was verified to survive the vendored Text::Markdown verbatim in every context.
- **Cache-safe**: it runs after the `bw_xboard_body_html` markdown cache, so the cache stores the literal token — attaching/detaching later can never serve stale ids from cached HTML.
- **Same markup as the gallery**: images emit `<img class="internal" src="attach.cgi?atid=…;name=/…">` (the existing fit-to-width CSS applies unchanged); non-images emit a filename link; an out-of-range position renders a visible `[첨부N 없음]` marker instead of vanishing (the gated-message lesson from #38).
- **Self-demonstrable**: tokens inside `<pre>`/`<code>` stay literal — an announcement can show its own syntax — and the strict no-spaces grammar is the escape hatch everywhere else. Filenames are HTML-escaped in the emitted markup.
- **Zero cost when unused**: a cheap match guard skips everything for token-free articles; token-carrying articles add one `get_attachset` query. No schema, no JS, no new endpoint.

**Accepted limitation** (positional, not identity-bound): detaching a *middle* attachment silently reaims the later tokens down one slot — only a now-out-of-range *tail* token shows the `[첨부N 없음]` marker; a shifted middle token is silent. The compose-once announcement flow this exists for never hits it, and binding a token to a stable id would need a write-path rewrite that freezes later-added attachments — deliberately not done.

## UX crumbs

The write form gains a one-line hint beside the attach button (`본문에 [[첨부1]]을 쓰면 …`), and the edit page's attachment rows show their position number (the read page's `<ol>` already numbers them).

## Codex review (2 rounds)

Round 1 found three real issues in the token resolver, all fixed by replacing a paired-tag regex split with a single linear scanner: a quadratic scan on unclosed `<pre>`/`<code>` (a read-path DoS on raw-HTML bodies), token substitution corrupting an HTML attribute, and case-sensitive `<pre>` matching. Round 2 surfaced two edge findings, both **accepted with reasons** (documented in code): the middle-detach drift above, and a literal `>` inside a quoted attribute ending the linear `<[^>]*>` tag match early (malformed HTML on an already-non-sanitizing surface; the strictly-linear alternative is a full char scanner, disproportionate here). Neither affects the compose-once flow.

## Smoke (EXPECTED 57 → 60)

A markdown article pins all four behaviors in one body — inline img for `[[첨부1]]`, link for `[[attach2]]`, `[첨부9 없음]` marker, and a fenced code block whose token stays literal — a plain-mode article pins img + marker, and a third (round-2) plain-mode article pins the context-safety fixes: a token inside uppercase `<PRE>` and inside an HTML attribute both stay literal while a bare text token resolves. Bracketed assertions use `grep -F` (the suite's `has()` is BRE, where `[` opens a bracket expression). All 60 green locally, plus a browser-verified screenshot of the rendered markdown article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzsEZVjq7dCLBbT99deqNS
