### PR TITLE
feat(read): poll-notice anchor chip — poll articles say so up top

### DIFF
--- a/board/skin/default/read.tmpl
+++ b/board/skin/default/read.tmpl
@@ -41,6 +41,13 @@
 </tmpl_if>
 </tmpl_if>
 
+<tmpl_if pollset>
+<!-- same poll.gif the article list marks titles with, same anchor-jump
+     idiom as the comment-form ▼ above: long articles bury the poll at
+     the bottom, so say it up front and link down -->
+<li class="body poll-notice"><a href="#article-<tmpl_var article_id>-poll"><img src="skin/default/images/poll.gif" alt="poll" class="icon poll" /> 설문이 있습니다 ▼</a></li>
+</tmpl_if>
+
 <li class="body text"><table class="safety wrapper"><tr><td><tmpl_if expired><img src="../user/photo.cgi?id=root" border="1" width="105" height="140" alt="photo"/>게시판 설정 읽기 유효기간이 지났습니다.</div><tmpl_else><tmpl_var body></tmpl_if></td></tr></table></li>
 
 <tmpl_if pollset>

--- a/t/smoke.sh
+++ b/t/smoke.sh
@@ -57,7 +57,7 @@
 set -u
 cd "$(dirname "$0")/.."
 
-EXPECTED=60
+EXPECTED=61
 PASS='test1234'
 CANARY_ARTICLE='CANARY-ARTICLE-b7a2f9'
 CANARY_TITLE='CANARY-TITLE-c7d4e2'
@@ -847,6 +847,13 @@ fetch "$J2" "$BASE/board/read.cgi?bid=2&aid=$xaid"
 [ "$CODE" = "200" ] || fail "xtab: read: HTTP $CODE"
 has "poll.cgi?bid=2;aid=$xaid" || fail "read page carries no cross-tab link"
 ok "article page links to the cross-tab entry page"
+
+# poll-notice anchor: a poll article says so up top and links down; a
+# poll-less article (tier 5's token article, still fetchable) must not
+has "href=\"#article-$xaid-poll\"" || fail "poll article carries no top anchor to its poll block"
+fetch "$J2" "$BASE/board/read.cgi?bid=2&aid=$tpaid"
+has "poll-notice" && fail "poll-less article renders a poll notice"
+ok "poll articles carry the top anchor chip; poll-less articles do not"
 
 login tester07; J7=$JAR
 fetch "$J7" "$BASE/board/poll.cgi?bid=2&aid=$xaid&mode=xtab&p1=$xp1&p2=$xp2"


### PR DESCRIPTION
Polls render after the body, so a long article buries its own question. The article list already marks poll articles with `poll.gif`, and the read page already anchor-jumps with the comment-form ▼ — this extends both precedents: a one-line chip above the body (`설문이 있습니다 ▼`, same icon) linking down to the existing `#article-N-poll` container. Template-only: no script, no queries, no new grammar.

Chosen **instead of** inline poll placement (`[[설문N]]` tokens): polls are per-viewer interactive forms wired to the ajax vote flow, so true inline placement needs script.js relocation choreography (the ajax vote re-render teleports the form back to the bottom) or template rendering from Board.pm — a different weight class than the static `[[첨부N]]` tokens. Discoverability is the actual pain; this solves it for one template line. Inline placement remains a possible follow-up if members ask once they've lived with poll v2.

Smoke (EXPECTED 60 → 61): the poll article carries the anchor href; a poll-less article renders no chip. All 61 green locally; browser-verified screenshot in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzsEZVjq7dCLBbT99deqNS